### PR TITLE
fix: Force Role recreation if `id` changes

### DIFF
--- a/internal/provider/role/role_resource.go
+++ b/internal/provider/role/role_resource.go
@@ -27,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -61,6 +63,9 @@ This should be unique and can be the name of an LDAP or SAML Group if you are us
 Matching Roles based on id will automatically be granted to LDAP or SAML users.`,
 				Required: true,
 				Optional: false,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Description: "The name of the role.",


### PR DESCRIPTION
Resolves #88 