### PR TITLE
fix: Further improved handling of bad or unaccessible NXMRM Url in Provider configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## X.Y.Z (UNRELEASED)
 
+BUG FIXES:
+* **Bug:** Further improve connectivity errors to Sonatype Nexus Repository without the provider crashinh [GH-105]
 
 ## 0.8.0 October 18, 2025
 

--- a/internal/provider/common/api.go
+++ b/internal/provider/common/api.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"reflect"
 	"syscall"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -36,10 +37,18 @@ func HandleApiError(message string, err *error, httpResponse *http.Response, res
 			fmt.Sprintf("Networking Error: %s (%v)", errorMessage, *err),
 		)
 	} else {
-		respDiags.AddError(
-			message,
-			fmt.Sprintf("%s: %s: %s", *err, httpResponse.Status, getResponseBody(httpResponse)),
-		)
+		if httpResponse != nil {
+			respDiags.AddError(
+				message,
+				fmt.Sprintf("%s: %s: %s", *err, httpResponse.Status, getResponseBody(httpResponse)),
+			)
+		} else {
+			respDiags.AddError(
+				message,
+				fmt.Sprintf("Unexpected Error: %v ('%s'): ", *err, reflect.TypeOf(*err)),
+			)
+
+		}
 	}
 }
 


### PR DESCRIPTION
Resolves #105 

Example outputs now with Bad or inaccessible URLs:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Sonatype Nexus Repository is not writable or contactable
│ 
│   with provider["sonatype-se.com/sonatype-community/sonatyperepo"],
│   on main.tf line 11, in provider "sonatyperepo":
│   11: provider "sonatyperepo" {
│ 
│ Unexpected Error: Get "https://qoughq2ohg2oigh2ioo/service/rest/v1/status/writable": dial tcp: lookup
│ qoughq2ohg2oigh2ioo: no such host ('*url.Error'): 
```

Also - untrusted Certificates will also be caught:
```
Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Sonatype Nexus Repository is not writable or contactable
│ 
│   with provider["sonatype-se.com/sonatype-community/sonatyperepo"],
│   on main.tf line 11, in provider "sonatyperepo":
│   11: provider "sonatyperepo" {
│ 
│ Unexpected Error: Get "https://test.somewhere.io/service/rest/v1/status/writable": tls: failed to verify
│ certificate: x509: certificate is valid for somewhere.io, not test.somewhere.io
│ ('*url.Error'): 
```