### PR TITLE
fix: Resources `sonatyperepo_capability_*` crashed provider when `notes` not supplied

### DIFF
--- a/internal/provider/model/capability_audit.go
+++ b/internal/provider/model/capability_audit.go
@@ -31,9 +31,9 @@ type CapabilityAuditModel struct {
 }
 
 func (m *CapabilityAuditModel) FromApiModel(api *v3.CapabilityDTO) {
-	m.Id = types.StringValue(*api.Id)
-	m.Notes = types.StringValue(*api.Notes)
-	m.Enabled = types.BoolValue(*api.Enabled)
+	m.Id = types.StringPointerValue(api.Id)
+	m.Notes = types.StringPointerValue(api.Notes)
+	m.Enabled = types.BoolPointerValue(api.Enabled)
 }
 
 func (m *CapabilityAuditModel) ToApiCreateModel(version common.SystemVersion) *v3.CapabilityDTO {

--- a/internal/provider/model/capability_core.go
+++ b/internal/provider/model/capability_core.go
@@ -42,9 +42,9 @@ type CapabilityCoreBaseUrlModel struct {
 }
 
 func (m *CapabilityCoreBaseUrlModel) FromApiModel(api *v3.CapabilityDTO) {
-	m.Id = types.StringValue(*api.Id)
-	m.Notes = types.StringValue(*api.Notes)
-	m.Enabled = types.BoolValue(*api.Enabled)
+	m.Id = types.StringPointerValue(api.Id)
+	m.Notes = types.StringPointerValue(api.Notes)
+	m.Enabled = types.BoolPointerValue(api.Enabled)
 	m.Properties = &CapabilityPropertiesCoreBaseUrl{}
 	m.Properties.Url = types.StringValue((*api.Properties)["url"])
 }

--- a/internal/provider/model/capability_firewall.go
+++ b/internal/provider/model/capability_firewall.go
@@ -43,9 +43,9 @@ type CapabilityFirewallAuditQuarantineModel struct {
 }
 
 func (m *CapabilityFirewallAuditQuarantineModel) FromApiModel(api *v3.CapabilityDTO) {
-	m.Id = types.StringValue(*api.Id)
-	m.Notes = types.StringValue(*api.Notes)
-	m.Enabled = types.BoolValue(*api.Enabled)
+	m.Id = types.StringPointerValue(api.Id)
+	m.Notes = types.StringPointerValue(api.Notes)
+	m.Enabled = types.BoolPointerValue(api.Enabled)
 	m.Properties = &CapabilityPropertiesFirewallAuditQuarantine{}
 	m.Properties.Quarantine = types.BoolValue(ParseBool(
 		(*api.Properties)["quarantine"],

--- a/internal/provider/model/capability_healthcheck.go
+++ b/internal/provider/model/capability_healthcheck.go
@@ -43,9 +43,9 @@ type CapabilityHealthcheckModel struct {
 }
 
 func (m *CapabilityHealthcheckModel) FromApiModel(api *v3.CapabilityDTO) {
-	m.Id = types.StringValue(*api.Id)
-	m.Notes = types.StringValue(*api.Notes)
-	m.Enabled = types.BoolValue(*api.Enabled)
+	m.Id = types.StringPointerValue(api.Id)
+	m.Notes = types.StringPointerValue(api.Notes)
+	m.Enabled = types.BoolPointerValue(api.Enabled)
 	m.Properties = &CapabilityPropertiesHealthcheck{}
 	m.Properties.ConfiguredForAllProxies = types.BoolValue(ParseBool(
 		(*api.Properties)["configuredForAll"],

--- a/internal/provider/model/capability_s3.go
+++ b/internal/provider/model/capability_s3.go
@@ -44,9 +44,9 @@ type CapabilityCustomS3RegionsModel struct {
 }
 
 func (m *CapabilityCustomS3RegionsModel) FromApiModel(api *v3.CapabilityDTO) {
-	m.Id = types.StringValue(*api.Id)
-	m.Notes = types.StringValue(*api.Notes)
-	m.Enabled = types.BoolValue(*api.Enabled)
+	m.Id = types.StringPointerValue(api.Id)
+	m.Notes = types.StringPointerValue(api.Notes)
+	m.Enabled = types.BoolPointerValue(api.Enabled)
 	m.Properties = &CapabilityPropertiesCustomS3Regions{}
 
 	// Regions

--- a/internal/provider/model/capability_security.go
+++ b/internal/provider/model/capability_security.go
@@ -42,9 +42,9 @@ type CapabilityRutAuthModel struct {
 }
 
 func (m *CapabilityRutAuthModel) FromApiModel(api *v3.CapabilityDTO) {
-	m.Id = types.StringValue(*api.Id)
-	m.Notes = types.StringValue(*api.Notes)
-	m.Enabled = types.BoolValue(*api.Enabled)
+	m.Id = types.StringPointerValue(api.Id)
+	m.Notes = types.StringPointerValue(api.Notes)
+	m.Enabled = types.BoolPointerValue(api.Enabled)
 	m.Properties = &CapabilityPropertiesRutAuth{}
 	m.Properties.HttpHeader = types.StringValue((*api.Properties)["http_header"])
 }

--- a/internal/provider/model/capability_ui.go
+++ b/internal/provider/model/capability_ui.go
@@ -45,9 +45,9 @@ type UiBrandingCapabilityModel struct {
 }
 
 func (m *UiBrandingCapabilityModel) FromApiModel(api *v3.CapabilityDTO) {
-	m.Id = types.StringValue(*api.Id)
-	m.Notes = types.StringValue(*api.Notes)
-	m.Enabled = types.BoolValue(*api.Enabled)
+	m.Id = types.StringPointerValue(api.Id)
+	m.Notes = types.StringPointerValue(api.Notes)
+	m.Enabled = types.BoolPointerValue(api.Enabled)
 	m.Properties = &CapabilityPropertiesUiBranding{}
 	m.Properties.FooterEnabled = types.BoolValue(ParseBool(
 		(*api.Properties)["footerEnabled"],

--- a/internal/provider/model/capability_webhook.go
+++ b/internal/provider/model/capability_webhook.go
@@ -70,9 +70,9 @@ type WebhookGlobalCapabilityModel struct {
 }
 
 func (m *WebhookGlobalCapabilityModel) FromApiModel(api *v3.CapabilityDTO) {
-	m.Id = types.StringValue(*api.Id)
-	m.Notes = types.StringValue(*api.Notes)
-	m.Enabled = types.BoolValue(*api.Enabled)
+	m.Id = types.StringPointerValue(api.Id)
+	m.Notes = types.StringPointerValue(api.Notes)
+	m.Enabled = types.BoolPointerValue(api.Enabled)
 	m.Properties = &CapabilityPropertiesWebhookGlobal{}
 	namesStr := (*api.Properties)["names"]
 	namesParts := strings.Split(namesStr, ",")


### PR DESCRIPTION
Resolves #222