### PR TITLE
doc: `sonatyperepo_system_config_ldap_connection` broken against NXRM 3.88 due to API regression

### DIFF
--- a/docs/resources/system_config_ldap_connection.md
+++ b/docs/resources/system_config_ldap_connection.md
@@ -3,12 +3,15 @@
 page_title: "sonatyperepo_system_config_ldap_connection Resource - sonatyperepo"
 subcategory: ""
 description: |-
-  Configure and LDAP connection
+  Configure and manage an LDAP connection.
+  WARNING: This does not work against Sonatype Nexus Repository 3.88.x due to a known bug in these versions.
 ---
 
 # sonatyperepo_system_config_ldap_connection (Resource)
 
-Configure and LDAP connection
+Configure and manage an LDAP connection.
+
+**WARNING: This does not work against Sonatype Nexus Repository 3.88.x due to a known bug in these versions.**
 
 
 

--- a/internal/provider/system/config_ldap_resource.go
+++ b/internal/provider/system/config_ldap_resource.go
@@ -56,7 +56,9 @@ func (r *systemConfigLdapResource) Metadata(_ context.Context, req resource.Meta
 // Schema defines the schema for the resource.
 func (r *systemConfigLdapResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = tfschema.Schema{
-		Description: "Configure and LDAP connection",
+		MarkdownDescription: `Configure and manage an LDAP connection.
+
+**WARNING: This does not work against Sonatype Nexus Repository 3.88.x due to a known bug in these versions.**`,
 		Attributes: map[string]tfschema.Attribute{
 			"id":   schema.ResourceComputedString("Internal LDAP server ID"),
 			"name": schema.ResourceRequiredString("LDAP connection name"),

--- a/internal/provider/system/config_ldap_resource_test.go
+++ b/internal/provider/system/config_ldap_resource_test.go
@@ -18,6 +18,7 @@ package system_test
 
 import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
+	"terraform-provider-sonatyperepo/internal/provider/testutil"
 	utils_test "terraform-provider-sonatyperepo/internal/provider/utils"
 	"testing"
 
@@ -34,6 +35,18 @@ func TestAccSystemConfigLdapResource(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
+		PreCheck: func() {
+			// Broken in NXRM 3.88
+			testutil.SkipIfNxrmVersionInRange(t, &common.SystemVersion{
+				Major: 3,
+				Minor: 88,
+				Patch: 0,
+			}, &common.SystemVersion{
+				Major: 3,
+				Minor: 88,
+				Patch: 99,
+			})
+		},
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
@@ -119,5 +132,4 @@ resource "sonatyperepo_system_config_ldap_connection" "ldap2" {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
-
 }


### PR DESCRIPTION
Resolves #276 (see also #260).