### PR TITLE
fix: Use `StateUpgrader` to handle schema version change for `sonatyperepo_blob_store_s3`

### DIFF
--- a/internal/provider/blob_store/blob_store_common_test.go
+++ b/internal/provider/blob_store/blob_store_common_test.go
@@ -31,6 +31,9 @@ const (
 	RES_ATTR_MEMBERS_COUNT    string = "members.#"
 	RES_ATTR_LAST_UPDATED     string = "last_updated"
 
+	RES_ATTR_S3_BUCKET_CONFIGURATION_PRE_SIGNED_ENABLED string = "bucket_configuration.pre_signed_url_enabled"
+	RES_ATTR_S3_BUCKET_CONFIGURATION_BUCKET_REGION      string = "bucket_configuration.bucket.region"
+
 	RES_NAME_FMT string = "%s.test"
 
 	RES_TYPE_BLOB_STORE_FILE  string = "sonatyperepo_blob_store_file"

--- a/internal/provider/blob_store/blob_store_s3_resource_test.go
+++ b/internal/provider/blob_store/blob_store_s3_resource_test.go
@@ -20,10 +20,17 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"terraform-provider-sonatyperepo/internal/provider"
 	utils_test "terraform-provider-sonatyperepo/internal/provider/utils"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	TEST_SKIPPED_S3_BLOBSTORE string = "S3 blob store resource tests require AWS credentials - set TF_ACC_S3_BLOB_STORE=1 to enable"
 )
 
 // TestAccBlobStoreS3ResourceValidation tests S3 resource validation without API calls
@@ -46,7 +53,7 @@ func TestAccBlobStoreS3ResourceWithCredentials(t *testing.T) {
 		ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
 		PreCheck: func() {
 			if os.Getenv("TF_ACC_S3_BLOB_STORE") != "1" {
-				t.Skip("S3 blob store resource tests require AWS credentials - set TF_ACC_S3_BLOB_STORE=1 to enable")
+				t.Skip(TEST_SKIPPED_S3_BLOBSTORE)
 			}
 		},
 		Steps: []resource.TestStep{
@@ -148,7 +155,7 @@ func TestAccBlobStoreS3ResourcePreSignedUrlWithCredentials(t *testing.T) {
 		ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
 		PreCheck: func() {
 			if os.Getenv("TF_ACC_S3_BLOB_STORE") != "1" {
-				t.Skip("S3 blob store resource tests require AWS credentials - set TF_ACC_S3_BLOB_STORE=1 to enable")
+				t.Skip(TEST_SKIPPED_S3_BLOBSTORE)
 			}
 		},
 		Steps: []resource.TestStep{
@@ -157,8 +164,8 @@ func TestAccBlobStoreS3ResourcePreSignedUrlWithCredentials(t *testing.T) {
 				Config: buildS3ResourcePreSignedUrlCompleteConfig("test-presigned-crud", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, RES_ATTR_NAME, "test-s3-presigned-test-presigned-crud"),
-					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, "bucket_configuration.0.pre_signed_url_enabled", "false"),
-					resource.TestCheckResourceAttrSet(RES_NAME_BLOB_STORE_S3, "bucket_configuration.0.bucket.0.region"),
+					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, RES_ATTR_S3_BUCKET_CONFIGURATION_PRE_SIGNED_ENABLED, "false"),
+					resource.TestCheckResourceAttrSet(RES_NAME_BLOB_STORE_S3, RES_ATTR_S3_BUCKET_CONFIGURATION_BUCKET_REGION),
 				),
 			},
 			// Update to pre_signed_url_enabled = true
@@ -166,7 +173,7 @@ func TestAccBlobStoreS3ResourcePreSignedUrlWithCredentials(t *testing.T) {
 				Config: buildS3ResourcePreSignedUrlCompleteConfig("test-presigned-crud", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, RES_ATTR_NAME, "test-s3-presigned-test-presigned-crud"),
-					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, "bucket_configuration.0.pre_signed_url_enabled", "true"),
+					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, RES_ATTR_S3_BUCKET_CONFIGURATION_PRE_SIGNED_ENABLED, "true"),
 				),
 			},
 			// Update back to pre_signed_url_enabled = false
@@ -174,7 +181,7 @@ func TestAccBlobStoreS3ResourcePreSignedUrlWithCredentials(t *testing.T) {
 				Config: buildS3ResourcePreSignedUrlCompleteConfig("test-presigned-crud", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, RES_ATTR_NAME, "test-s3-presigned-test-presigned-crud"),
-					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, "bucket_configuration.0.pre_signed_url_enabled", "false"),
+					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, RES_ATTR_S3_BUCKET_CONFIGURATION_PRE_SIGNED_ENABLED, "false"),
 				),
 			},
 			// Import and verify
@@ -193,7 +200,7 @@ func TestAccBlobStoreS3ResourcePreSignedUrlDefault(t *testing.T) {
 		ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
 		PreCheck: func() {
 			if os.Getenv("TF_ACC_S3_BLOB_STORE") != "1" {
-				t.Skip("S3 blob store resource tests require AWS credentials - set TF_ACC_S3_BLOB_STORE=1 to enable")
+				t.Skip(TEST_SKIPPED_S3_BLOBSTORE)
 			}
 		},
 		Steps: []resource.TestStep{
@@ -202,7 +209,51 @@ func TestAccBlobStoreS3ResourcePreSignedUrlDefault(t *testing.T) {
 				Config: buildS3ResourcePreSignedUrlCompleteConfigOmitted("test-presigned-default"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, RES_ATTR_NAME, "test-s3-presigned-test-presigned-default"),
-					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, "bucket_configuration.0.pre_signed_url_enabled", "false"),
+					resource.TestCheckResourceAttr(RES_NAME_BLOB_STORE_S3, RES_ATTR_S3_BUCKET_CONFIGURATION_PRE_SIGNED_ENABLED, "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBlobStoreS3ResourceStateUpgradeV0ToV1(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if os.Getenv("TF_ACC_S3_BLOB_STORE") != "1" {
+				t.Skip(TEST_SKIPPED_S3_BLOBSTORE)
+			}
+		},
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create resource with old provider version (v0.17.0)
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"sonatyperepo": {
+						Source:            "sonatype-nexus-community/sonatyperepo",
+						VersionConstraint: "0.17.0", // Last version without pre_signed_url_enabled
+					},
+				},
+				Config: buildS3ResourcePreSignedUrlConfigOmitted("upgrade-v0-v1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(fmt.Sprintf(RES_NAME_FMT, RES_TYPE_BLOB_STORE_S3), RES_ATTR_NAME, "test-s3-presigned-upgrade-v0-v1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf(RES_NAME_FMT, RES_TYPE_BLOB_STORE_S3), RES_ATTR_S3_BUCKET_CONFIGURATION_BUCKET_REGION, "eu-west-2"),
+				),
+			},
+			{
+				// Step 2: Upgrade to current provider version
+				ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
+					"sonatyperepo": providerserver.NewProtocol6WithError(provider.New("test")()),
+				},
+				Config: buildS3ResourcePreSignedUrlConfigOmitted("upgrade-v0-v1"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify pre_signed_url_enabled was added by state upgrade
+					resource.TestCheckResourceAttr(
+						fmt.Sprintf(RES_NAME_FMT, RES_TYPE_BLOB_STORE_S3),
+						RES_ATTR_S3_BUCKET_CONFIGURATION_PRE_SIGNED_ENABLED,
+						"false",
+					),
+					// Verify other fields unchanged
+					resource.TestCheckResourceAttr(fmt.Sprintf(RES_NAME_FMT, RES_TYPE_BLOB_STORE_S3), RES_ATTR_NAME, "test-s3-presigned-upgrade-v0-v1"),
+					resource.TestCheckResourceAttr(fmt.Sprintf(RES_NAME_FMT, RES_TYPE_BLOB_STORE_S3), RES_ATTR_S3_BUCKET_CONFIGURATION_BUCKET_REGION, "eu-west-2"),
 				),
 			},
 		},

--- a/internal/provider/common/resource.go
+++ b/internal/provider/common/resource.go
@@ -27,9 +27,10 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &BaseResource{}
-	_ resource.ResourceWithConfigure   = &BaseResource{}
-	_ resource.ResourceWithImportState = &BaseResource{}
+	_ resource.Resource                 = &BaseResource{}
+	_ resource.ResourceWithConfigure    = &BaseResource{}
+	_ resource.ResourceWithImportState  = &BaseResource{}
+	_ resource.ResourceWithUpgradeState = &BaseResource{}
 )
 
 // BaseResource is the resource implementation for Sonatype Nexus Repository resources.
@@ -40,6 +41,11 @@ type BaseResource struct {
 	Client       *sonatyperepo.APIClient
 	NxrmVersion  SystemVersion
 	NxrmWritable bool
+}
+
+// UpgradeState implements resource.ResourceWithUpgradeState.
+func (r *BaseResource) UpgradeState(context.Context) map[int64]resource.StateUpgrader {
+	panic("unimplemented")
 }
 
 // ImportState implements resource.ResourceWithImportState.

--- a/internal/provider/model/blob_store.go
+++ b/internal/provider/model/blob_store.go
@@ -121,13 +121,21 @@ func (m *BlobStoreGroupModel) mapCommonGroupFields(api interface {
 
 // BlobStoreS3Model
 // ------------------------------------
-type BlobStoreS3Model struct {
+type BlobStoreS3ModelV0 struct {
+	Name                types.String                           `tfsdk:"name"`
+	Type                types.String                           `tfsdk:"type"`
+	SoftQuota           *BlobStoreSoftQuota                    `tfsdk:"soft_quota"`
+	BucketConfiguration *BlobStoreS3BucketConfigurationModelV0 `tfsdk:"bucket_configuration"`
+	LastUpdated         types.String                           `tfsdk:"last_updated"`
+}
+type BlobStoreS3ModelV1 struct {
 	Name                types.String                         `tfsdk:"name"`
 	Type                types.String                         `tfsdk:"type"`
 	SoftQuota           *BlobStoreSoftQuota                  `tfsdk:"soft_quota"`
 	BucketConfiguration *BlobStoreS3BucketConfigurationModel `tfsdk:"bucket_configuration"`
 	LastUpdated         types.String                         `tfsdk:"last_updated"`
 }
+type BlobStoreS3Model = BlobStoreS3ModelV1
 
 func (m *BlobStoreS3Model) MapFromApi(api *v3.S3BlobStoreApiModel) {
 	m.Name = types.StringValue(api.Name)
@@ -149,13 +157,20 @@ func (m *BlobStoreS3Model) MapToApi(api *v3.S3BlobStoreApiModel) {
 
 // BlobStoreS3BucketConfigurationModel
 // ------------------------------------
-type BlobStoreS3BucketConfigurationModel struct {
+type BlobStoreS3BucketConfigurationModelV0 struct {
+	Bucket                   BlobStoreS3BucketModel                    `tfsdk:"bucket"`
+	Encryption               *BlobStoreS3Encryption                    `tfsdk:"encryption"`
+	BucketSecurity           *BlobStoreS3BucketSecurityModel           `tfsdk:"bucket_security"`
+	AdvancedBucketConnection *BlobStoreS3AdvancedBucketConnectionModel `tfsdk:"advanced_bucket_connection"`
+}
+type BlobStoreS3BucketConfigurationModelV1 struct {
 	Bucket                   BlobStoreS3BucketModel                    `tfsdk:"bucket"`
 	Encryption               *BlobStoreS3Encryption                    `tfsdk:"encryption"`
 	BucketSecurity           *BlobStoreS3BucketSecurityModel           `tfsdk:"bucket_security"`
 	AdvancedBucketConnection *BlobStoreS3AdvancedBucketConnectionModel `tfsdk:"advanced_bucket_connection"`
 	PreSignedUrlEnabled      types.Bool                                `tfsdk:"pre_signed_url_enabled"`
 }
+type BlobStoreS3BucketConfigurationModel = BlobStoreS3BucketConfigurationModelV1
 
 func (m *BlobStoreS3BucketConfigurationModel) MapFromApi(api *v3.S3BlobStoreApiBucketConfiguration) {
 	m.Bucket.MapFromApi(&api.Bucket)
@@ -168,7 +183,11 @@ func (m *BlobStoreS3BucketConfigurationModel) MapFromApi(api *v3.S3BlobStoreApiB
 	if api.AdvancedBucketConnection != nil {
 		m.AdvancedBucketConnection.MapFromApi(api.AdvancedBucketConnection)
 	}
-	m.PreSignedUrlEnabled = types.BoolPointerValue(api.PreSignedUrlEnabled)
+	if api.PreSignedUrlEnabled == nil {
+		m.PreSignedUrlEnabled = types.BoolValue(false)
+	} else {
+		m.PreSignedUrlEnabled = types.BoolPointerValue(api.PreSignedUrlEnabled)
+	}
 }
 
 func (m *BlobStoreS3BucketConfigurationModel) MapToApi(api *v3.S3BlobStoreApiBucketConfiguration) {


### PR DESCRIPTION
Resolves #281 