### PR TITLE
fix: `null` interpreted as `0` for `max_connection_pool_size` #314

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 _TBC_
 
+BUG FIXES:
+* `null` value for `sonatyperepo_blob_store_s3.bucket_configuration.advanced_bucket_configuration.max_connection_pool_size` was interpretted as a `0` leading to inconsistent state [GH-314]
+
 ## 1.0.1 February 11, 2026
 
 BUG FIXES:

--- a/internal/provider/model/blob_store.go
+++ b/internal/provider/model/blob_store.go
@@ -313,7 +313,9 @@ func (m *BlobStoreS3AdvancedBucketConnectionModel) MapToApi(api *v3.S3BlobStoreA
 	api.Endpoint = m.Endpoint.ValueStringPointer()
 	api.SignerType = m.SignerType.ValueStringPointer()
 	api.ForcePathStyle = m.ForcePathStyle.ValueBoolPointer()
-	api.MaxConnectionPoolSize = util.Int32ToPtr(int32(m.MaxConnectionPoolSize.ValueInt64()))
+	if !m.MaxConnectionPoolSize.IsNull() {
+		api.MaxConnectionPoolSize = util.Int32ToPtr(int32(m.MaxConnectionPoolSize.ValueInt64()))
+	}
 }
 
 // BlobStoreGoogleCloudModel


### PR DESCRIPTION
Resolves #314 