### PR TITLE
fix: `enabled` must be supplied if `repository_firewall` block is supplied

### DIFF
--- a/docs/resources/repository_cargo_proxy.md
+++ b/docs/resources/repository_cargo_proxy.md
@@ -178,9 +178,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_cocoapods_proxy.md
+++ b/docs/resources/repository_cocoapods_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_composer_proxy.md
+++ b/docs/resources/repository_composer_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_conan_proxy.md
+++ b/docs/resources/repository_conan_proxy.md
@@ -176,9 +176,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_conda_proxy.md
+++ b/docs/resources/repository_conda_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_docker_proxy.md
+++ b/docs/resources/repository_docker_proxy.md
@@ -207,9 +207,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_go_proxy.md
+++ b/docs/resources/repository_go_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_huggingface_proxy.md
+++ b/docs/resources/repository_huggingface_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_maven2_proxy.md
+++ b/docs/resources/repository_maven2_proxy.md
@@ -183,9 +183,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_maven_proxy.md
+++ b/docs/resources/repository_maven_proxy.md
@@ -144,9 +144,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_npm_proxy.md
+++ b/docs/resources/repository_npm_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `pccs_enabled` (Boolean) Whether Policy-Compliant Component Selection is enabled. See [documentatation](https://help.sonatype.com/en/policy-compliant-component-selection.html) for details.
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 

--- a/docs/resources/repository_nuget_proxy.md
+++ b/docs/resources/repository_nuget_proxy.md
@@ -180,9 +180,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_pypi_proxy.md
+++ b/docs/resources/repository_pypi_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `pccs_enabled` (Boolean) Whether Policy-Compliant Component Selection is enabled. See [documentatation](https://help.sonatype.com/en/policy-compliant-component-selection.html) for details.
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 

--- a/docs/resources/repository_r_proxy.md
+++ b/docs/resources/repository_r_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_raw_proxy.md
+++ b/docs/resources/repository_raw_proxy.md
@@ -176,9 +176,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_ruby_gems_proxy.md
+++ b/docs/resources/repository_ruby_gems_proxy.md
@@ -133,9 +133,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_rubygems_proxy.md
+++ b/docs/resources/repository_rubygems_proxy.md
@@ -167,9 +167,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/docs/resources/repository_yum_proxy.md
+++ b/docs/resources/repository_yum_proxy.md
@@ -168,9 +168,12 @@ Optional:
 <a id="nestedatt--repository_firewall"></a>
 ### Nested Schema for `repository_firewall`
 
-Optional:
+Required:
 
 - `enabled` (Boolean) Whether to enable Sonatype Repository Firewall for this Repository
+
+Optional:
+
 - `quarantine` (Boolean) Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).
 
 Read-Only:

--- a/internal/provider/capability/capability_helpers.go
+++ b/internal/provider/capability/capability_helpers.go
@@ -92,16 +92,15 @@ func (ch *CapabilityHelper) CapabilityExists(ctx context.Context, repositoryId s
 }
 
 // CreateCapability creates a capability for a repository
-func (ch *CapabilityHelper) CreateCapability(ctx context.Context, repositoryId string, quarantineEnabled bool, diags *diag.Diagnostics) *v3.CapabilityDTO {
+func (ch *CapabilityHelper) CreateCapability(ctx context.Context, repositoryId string, capabilityEnabled, quarantineEnabled bool, diags *diag.Diagnostics) *v3.CapabilityDTO {
 	// Create the capability request
-	enabled := true
 	properties := map[string]string{
 		"repository": repositoryId,
 		"quarantine": fmt.Sprintf("%t", quarantineEnabled),
 	}
 	capabilityRequest := v3.CapabilityDTO{
 		Type:       ch.capabilityType.StringPointer(),
-		Enabled:    &enabled,
+		Enabled:    &capabilityEnabled,
 		Properties: &properties,
 	}
 
@@ -120,7 +119,7 @@ func (ch *CapabilityHelper) CreateCapability(ctx context.Context, repositoryId s
 }
 
 // UpdateCapability updates an existing capability
-func (ch *CapabilityHelper) UpdateCapability(ctx context.Context, capabilityId string, repositoryId string, capabilityEnabled bool, quarantineEnabled bool, diags *diag.Diagnostics) (*v3.CapabilityDTO, error) {
+func (ch *CapabilityHelper) UpdateCapability(ctx context.Context, capabilityId string, repositoryId string, capabilityEnabled, quarantineEnabled bool, diags *diag.Diagnostics) (*v3.CapabilityDTO, error) {
 	properties := map[string]string{
 		"repository": repositoryId,
 		"quarantine": fmt.Sprintf("%t", quarantineEnabled),

--- a/internal/provider/repository/format/apt.go
+++ b/internal/provider/repository/format/apt.go
@@ -146,7 +146,7 @@ func (f *AptRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any {
 }
 
 // --------------------------------------------
-// PROXY Maven Format Functions
+// PROXY APT Format Functions
 // --------------------------------------------
 func (f *AptRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type

--- a/internal/provider/repository/format/cargo.go
+++ b/internal/provider/repository/format/cargo.go
@@ -236,6 +236,19 @@ func (f *CargoRepositoryFormatProxy) UpateStateWithCapability(state any, capabil
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *CargoRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryCargoProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryCargoProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *CargoRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryCargoProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/cocoapods.go
+++ b/internal/provider/repository/format/cocoapods.go
@@ -153,6 +153,19 @@ func (f *CocoaPodsRepositoryFormatProxy) UpateStateWithCapability(state any, cap
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *CocoaPodsRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryCocoaPodsProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryCocoaPodsProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *CocoaPodsRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryCocoaPodsProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/common.go
+++ b/internal/provider/repository/format/common.go
@@ -157,6 +157,11 @@ func (f *BaseRepositoryFormat) UpateStateWithCapability(state any, capability *s
 	panic("Unimplemented")
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *BaseRepositoryFormat) HasFirewallConfig(state any) bool {
+	return false
+}
+
 func (f *BaseRepositoryFormat) GetRepositoryFirewallEnabled(state any) bool {
 	return false
 }
@@ -202,6 +207,7 @@ type RepositoryFormat interface {
 	SupportsRepositoryFirewall() bool
 	SupportsRepositoryFirewallPccs() bool
 	GetRepositoryId(state any) string
+	HasFirewallConfig(state any) bool
 	GetRepositoryFirewallEnabled(state any) bool
 	GetRepositoryFirewallQuarantineEnabled(state any) bool
 	GetRepositoryFirewallPccsEnabled(state any) bool

--- a/internal/provider/repository/format/composer.go
+++ b/internal/provider/repository/format/composer.go
@@ -153,6 +153,19 @@ func (f *ComposerRepositoryFormatProxy) UpateStateWithCapability(state any, capa
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *ComposerRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryComposerProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryComposerProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *ComposerRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryComposerProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/conan.go
+++ b/internal/provider/repository/format/conan.go
@@ -239,6 +239,19 @@ func (f *ConanRepositoryFormatProxy) UpateStateWithCapability(state any, capabil
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *ConanRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryConanProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryConanProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *ConanRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryConanProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/conda.go
+++ b/internal/provider/repository/format/conda.go
@@ -153,6 +153,19 @@ func (f *CondaRepositoryFormatProxy) UpateStateWithCapability(state any, capabil
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *CondaRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryCondaProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryCondaProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *CondaRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryCondaProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/docker.go
+++ b/internal/provider/repository/format/docker.go
@@ -265,8 +265,23 @@ func (f *DockerRepositoryFormatProxy) UpateStateWithCapability(state any, capabi
 			stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 		}
 		stateModel.FirewallAuditAndQuarantine.MapFromCapabilityDTO(capability)
+	} else {
+		stateModel.FirewallAuditAndQuarantine = nil
 	}
 	return stateModel
+}
+
+// Returns true only if `repository_firewall` block is supplied
+func (f *DockerRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryDockerProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryDockerProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
 }
 
 func (f *DockerRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
@@ -287,7 +302,10 @@ func (f *DockerRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(sta
 	if state != nil {
 		stateModel = (state).(model.RepositoryDockerProxyModel)
 	}
-	return stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool()
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool()
+	}
+	return false
 }
 
 // --------------------------------------------

--- a/internal/provider/repository/format/go.go
+++ b/internal/provider/repository/format/go.go
@@ -157,6 +157,19 @@ func (f *GoRepositoryFormatProxy) UpateStateWithCapability(state any, capability
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *GoRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryGoProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryGoProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *GoRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryGoProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/huggingface.go
+++ b/internal/provider/repository/format/huggingface.go
@@ -153,6 +153,19 @@ func (f *HuggingFaceRepositoryFormatProxy) UpateStateWithCapability(state any, c
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *HuggingFaceRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryHuggingFaceProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryHuggingFaceProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *HuggingFaceRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryHuggingFaceProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/maven.go
+++ b/internal/provider/repository/format/maven.go
@@ -239,6 +239,19 @@ func (f *MavenRepositoryFormatProxy) UpateStateWithCapability(state any, capabil
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *MavenRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryMavenProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryMavenProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *MavenRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryMavenProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/npm.go
+++ b/internal/provider/repository/format/npm.go
@@ -247,6 +247,19 @@ func (f *NpmRepositoryFormatProxy) UpateStateWithCapability(state any, capabilit
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *NpmRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryNpmProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryNpmProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *NpmRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryNpmProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/nuget.go
+++ b/internal/provider/repository/format/nuget.go
@@ -244,6 +244,19 @@ func (f *NugetRepositoryFormatProxy) UpateStateWithCapability(state any, capabil
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *NugetRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryNugetProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryNugetProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *NugetRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryNugetProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/proxy.go
+++ b/internal/provider/repository/format/proxy.go
@@ -97,7 +97,7 @@ func commonProxyFirewallAuditQuarantineAttribute(supportsPccs bool) tfschema.Sin
 **Requires Sonatype Nexus Repository 3.84.0 or later.`,
 		map[string]tfschema.Attribute{
 			"capability_id": schema.ResourceComputedString("Internal ID of the Audit & Quarantine Capability created for this Repository"),
-			"enabled":       schema.ResourceOptionalBoolWithDefault("Whether to enable Sonatype Repository Firewall for this Repository", false),
+			"enabled":       schema.ResourceRequiredBool("Whether to enable Sonatype Repository Firewall for this Repository"),
 			"quarantine":    schema.ResourceOptionalBoolWithDefault("Whether Quarantine functionallity is enabled (if false - just run in Audit mode) - see [documentation](https://help.sonatype.com/en/firewall-quarantine.html).", false),
 		},
 	)

--- a/internal/provider/repository/format/pypi.go
+++ b/internal/provider/repository/format/pypi.go
@@ -243,6 +243,19 @@ func (f *PyPiRepositoryFormatProxy) UpateStateWithCapability(state any, capabili
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *PyPiRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryPyPiProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryPyPiProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *PyPiRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryPyPiProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/r.go
+++ b/internal/provider/repository/format/r.go
@@ -230,6 +230,18 @@ func (f *RRepositoryFormatProxy) UpateStateWithCapability(state any, capability 
 	return stateModel
 }
 
+func (f *RRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositorRProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositorRProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *RRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositorRProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/raw.go
+++ b/internal/provider/repository/format/raw.go
@@ -245,6 +245,19 @@ func (f *RawRepositoryFormatProxy) UpateStateWithCapability(state any, capabilit
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *RawRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryRawProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryRawProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *RawRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryRawProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/ruby_gems.go
+++ b/internal/provider/repository/format/ruby_gems.go
@@ -238,6 +238,19 @@ func (f *RubyGemsRepositoryFormatProxy) UpateStateWithCapability(state any, capa
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *RubyGemsRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositorRubyGemsProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositorRubyGemsProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *RubyGemsRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositorRubyGemsProxyModel
 	// During import, state might be nil, so we create a new model

--- a/internal/provider/repository/format/yum.go
+++ b/internal/provider/repository/format/yum.go
@@ -246,6 +246,19 @@ func (f *YumRepositoryFormatProxy) UpateStateWithCapability(state any, capabilit
 	return stateModel
 }
 
+// Returns true only if `repository_firewall` block is supplied
+func (f *YumRepositoryFormatProxy) HasFirewallConfig(state any) bool {
+	var stateModel model.RepositoryYumProxyModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryYumProxyModel)
+	}
+	if stateModel.FirewallAuditAndQuarantine != nil {
+		return true
+	}
+	return false
+}
+
 func (f *YumRepositoryFormatProxy) GetRepositoryFirewallEnabled(state any) bool {
 	var stateModel model.RepositoryYumProxyModel
 	// During import, state might be nil, so we create a new model


### PR DESCRIPTION
Resolves #345 