### PR TITLE
fix: Allow empty string as `override_url` for resource `sonatyperepo_capability_outreach_management` 

### DIFF
--- a/internal/provider/capability/capability_type/outreach.go
+++ b/internal/provider/capability/capability_type/outreach.go
@@ -78,8 +78,8 @@ func (f *OutreachCapability) PropertiesSchema() map[string]tfschema.Attribute {
 	return map[string]tfschema.Attribute{
 		"override_url": schema.ResourceOptionalStringWithRegex(
 			"Override external URL for downloading new Outreach content.",
-			regexp.MustCompile(`^https?://[^\s]+$`),
-			"Must be a valid http:// or https:// URL",
+			regexp.MustCompile(`^(https?://[^\s]+|)$`),
+			"Must be a valid http:// or https:// URL or empty string.",
 		),
 		"always_remote": schema.ResourceOptionalBoolWithDefault(
 			"Always check the remote server for updates.",

--- a/internal/provider/capability/capability_x_resource_test.go
+++ b/internal/provider/capability/capability_x_resource_test.go
@@ -547,6 +547,26 @@ resource "%s" "cap" {
 					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrOverrideUrl), "https://some.url.tld"),
 				),
 			},
+			// Update testing
+			{
+				Config: fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "cap" {
+  notes = "example-notes-%s-updated"
+  enabled = true
+  properties = {
+    always_remote = true
+    override_url  = ""
+  }
+}
+`, resourceOutreachManagement, randomString),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, resourceAttrId),
+					resource.TestCheckResourceAttr(resourceName, resourceAttrNotes, fmt.Sprintf(notesUpdatedFString, randomString)),
+					resource.TestCheckResourceAttr(resourceName, resourceAttrEnabled, "true"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrAlwaysRemote), "true"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrOverrideUrl), ""),
+				),
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})


### PR DESCRIPTION
Resolves #375