### PR TITLE
fix: change frequency.start_date to int64

### DIFF
--- a/docs/resources/task_blobstore_compact.md
+++ b/docs/resources/task_blobstore_compact.md
@@ -62,7 +62,7 @@ Optional:
 
 - For "weekly" schedule allowed values, 1 to 7.
 - For "monthly" schedule allowed values, 1 to 31.
-- `start_date` (Number) Start date of the task represented in unix timestamp. Does not apply for "manual" schedule.
+- `start_date` (Number) Start date of the task represented in unix timestamp. Sonatype Nexus Repository persists this in milliseconds, so values for any modern date are 13 digits (e.g. `1777167000000` for 2026-04-26 01:30 UTC). Does not apply for "manual" schedule.
 - `timezone_offset` (String) The offset time zone of the client. Example: -05:00
 
 

--- a/docs/resources/task_license_expiration_notification.md
+++ b/docs/resources/task_license_expiration_notification.md
@@ -60,5 +60,5 @@ Optional:
 
 - For "weekly" schedule allowed values, 1 to 7.
 - For "monthly" schedule allowed values, 1 to 31.
-- `start_date` (Number) Start date of the task represented in unix timestamp. Does not apply for "manual" schedule.
+- `start_date` (Number) Start date of the task represented in unix timestamp. Sonatype Nexus Repository persists this in milliseconds, so values for any modern date are 13 digits (e.g. `1777167000000` for 2026-04-26 01:30 UTC). Does not apply for "manual" schedule.
 - `timezone_offset` (String) The offset time zone of the client. Example: -05:00

--- a/docs/resources/task_malware_remediator.md
+++ b/docs/resources/task_malware_remediator.md
@@ -70,7 +70,7 @@ Optional:
 
 - For "weekly" schedule allowed values, 1 to 7.
 - For "monthly" schedule allowed values, 1 to 31.
-- `start_date` (Number) Start date of the task represented in unix timestamp. Does not apply for "manual" schedule.
+- `start_date` (Number) Start date of the task represented in unix timestamp. Sonatype Nexus Repository persists this in milliseconds, so values for any modern date are 13 digits (e.g. `1777167000000` for 2026-04-26 01:30 UTC). Does not apply for "manual" schedule.
 - `timezone_offset` (String) The offset time zone of the client. Example: -05:00
 
 

--- a/docs/resources/task_repair_create_browse_nodes.md
+++ b/docs/resources/task_repair_create_browse_nodes.md
@@ -46,7 +46,7 @@ Optional:
 
 - For "weekly" schedule allowed values, 1 to 7.
 - For "monthly" schedule allowed values, 1 to 31.
-- `start_date` (Number) Start date of the task represented in unix timestamp. Does not apply for "manual" schedule.
+- `start_date` (Number) Start date of the task represented in unix timestamp. Sonatype Nexus Repository persists this in milliseconds, so values for any modern date are 13 digits (e.g. `1777167000000` for 2026-04-26 01:30 UTC). Does not apply for "manual" schedule.
 - `timezone_offset` (String) The offset time zone of the client. Example: -05:00
 
 

--- a/docs/resources/task_repository_docker_gc.md
+++ b/docs/resources/task_repository_docker_gc.md
@@ -63,7 +63,7 @@ Optional:
 
 - For "weekly" schedule allowed values, 1 to 7.
 - For "monthly" schedule allowed values, 1 to 31.
-- `start_date` (Number) Start date of the task represented in unix timestamp. Does not apply for "manual" schedule.
+- `start_date` (Number) Start date of the task represented in unix timestamp. Sonatype Nexus Repository persists this in milliseconds, so values for any modern date are 13 digits (e.g. `1777167000000` for 2026-04-26 01:30 UTC). Does not apply for "manual" schedule.
 - `timezone_offset` (String) The offset time zone of the client. Example: -05:00
 
 

--- a/docs/resources/task_repository_docker_upload_purge.md
+++ b/docs/resources/task_repository_docker_upload_purge.md
@@ -63,7 +63,7 @@ Optional:
 
 - For "weekly" schedule allowed values, 1 to 7.
 - For "monthly" schedule allowed values, 1 to 31.
-- `start_date` (Number) Start date of the task represented in unix timestamp. Does not apply for "manual" schedule.
+- `start_date` (Number) Start date of the task represented in unix timestamp. Sonatype Nexus Repository persists this in milliseconds, so values for any modern date are 13 digits (e.g. `1777167000000` for 2026-04-26 01:30 UTC). Does not apply for "manual" schedule.
 - `timezone_offset` (String) The offset time zone of the client. Example: -05:00
 
 

--- a/docs/resources/task_repository_maven_remove_snapshots.md
+++ b/docs/resources/task_repository_maven_remove_snapshots.md
@@ -66,7 +66,7 @@ Optional:
 
 - For "weekly" schedule allowed values, 1 to 7.
 - For "monthly" schedule allowed values, 1 to 31.
-- `start_date` (Number) Start date of the task represented in unix timestamp. Does not apply for "manual" schedule.
+- `start_date` (Number) Start date of the task represented in unix timestamp. Sonatype Nexus Repository persists this in milliseconds, so values for any modern date are 13 digits (e.g. `1777167000000` for 2026-04-26 01:30 UTC). Does not apply for "manual" schedule.
 - `timezone_offset` (String) The offset time zone of the client. Example: -05:00
 
 

--- a/internal/provider/model/common.go
+++ b/internal/provider/model/common.go
@@ -49,7 +49,7 @@ func StructToMap(v interface{}) *map[string]string {
 	result := make(map[string]string)
 
 	val := reflect.ValueOf(v)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 
@@ -93,7 +93,7 @@ func fieldValueToString(v reflect.Value) string {
 		return strconv.FormatFloat(v.Float(), 'f', -1, 64)
 	case reflect.Bool:
 		return strconv.FormatBool(v.Bool())
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if v.IsNil() {
 			return ""
 		}

--- a/internal/provider/model/task.go
+++ b/internal/provider/model/task.go
@@ -25,7 +25,7 @@ import (
 // ----------------------------------------
 type taskFrequency struct {
 	Schedule       types.String  `tfsdk:"schedule"`
-	StartDate      types.Int32   `tfsdk:"start_date"`
+	StartDate      types.Int64   `tfsdk:"start_date"`
 	TimezoneOffset types.String  `tfsdk:"timezone_offset"`
 	RecurringDays  []types.Int32 `tfsdk:"recurring_days"`
 	CronExpression types.String  `tfsdk:"cron_expression"`
@@ -38,12 +38,7 @@ func (f *taskFrequency) ToApiModel(api *v3.FrequencyXO) {
 		api.RecurringDays = append(api.RecurringDays, rd.ValueInt32())
 	}
 	api.Schedule = f.Schedule.ValueString()
-	if f.StartDate.ValueInt32Pointer() != nil {
-		val := int64(*f.StartDate.ValueInt32Pointer())
-		api.StartDate = &val
-	} else {
-		api.StartDate = nil
-	}
+	api.StartDate = f.StartDate.ValueInt64Pointer()
 	api.TimeZoneOffset = f.TimezoneOffset.ValueStringPointer()
 }
 

--- a/internal/provider/repository/format/common.go
+++ b/internal/provider/repository/format/common.go
@@ -98,7 +98,7 @@ func (f *BaseRepositoryFormat) ValidateRepositoryForImport(repositoryData any, e
 
 	// Handle both *string and string types
 	var actualFormat string
-	if formatField.Kind() == reflect.Ptr {
+	if formatField.Kind() == reflect.Pointer {
 		if formatField.IsNil() {
 			return fmt.Errorf(errRepositoryFormatNil, expectedFormat)
 		}
@@ -122,7 +122,7 @@ func (f *BaseRepositoryFormat) ValidateRepositoryForImport(repositoryData any, e
 
 	// Handle both *string and string types
 	var actualType string
-	if typeField.Kind() == reflect.Ptr {
+	if typeField.Kind() == reflect.Pointer {
 		if typeField.IsNil() {
 			expectedTypeStr := expectedType.String()
 			return fmt.Errorf(errRepositoryTypeNil, expectedTypeStr)

--- a/internal/provider/task/task_common.go
+++ b/internal/provider/task/task_common.go
@@ -267,8 +267,8 @@ func taskSchema(tt tasktype.TaskTypeI) tfschema.Schema {
 					common.FREQUENCY_SCHEDULE_MONTHLY,
 					common.FREQUENCY_SCHEDULE_CRON,
 				),
-				"start_date": schema.ResourceOptionalInt32(
-					"Start date of the task represented in unix timestamp. Does not apply for \"manual\" schedule.",
+				"start_date": schema.ResourceOptionalInt64(
+					"Start date of the task represented in unix timestamp. Sonatype Nexus Repository persists this in milliseconds, so values for any modern date are 13 digits (e.g. `1777167000000` for 2026-04-26 01:30 UTC). Does not apply for \"manual\" schedule.",
 				),
 				"timezone_offset": schema.ResourceOptionalString("The offset time zone of the client. Example: -05:00"),
 				"recurring_days": func() tfschema.ListAttribute {


### PR DESCRIPTION
Nexus persists `frequency.startDate` as unix milliseconds (`*int64` in the OpenAPI model). The schema was `Int32` so any modern ms timestamp overflows; values that did fit were sent unchanged to Nexus and interpreted as ms (e.g 2026 → 1970).

Switch the schema and model to `Int64`, drop the int32→int64 cast in `taskFrequency.ToApiModel`, and clarify the doc string that the unit is milliseconds.

Resolves #405 