### PR TITLE
fix: pass planModel instead of stateModel to UpdateStateFromApi in Up…

### DIFF
--- a/internal/provider/repository/repository_common.go
+++ b/internal/provider/repository/repository_common.go
@@ -346,7 +346,7 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Map to state
-	stateModel = r.RepositoryFormat.UpdateStateFromApi(stateModel, apiResponse)
+	stateModel = r.RepositoryFormat.UpdateStateFromApi(planModel, apiResponse)
 	// Copy various fields not returned by a READ from Plan
 	stateModel = r.RepositoryFormat.UpdateStateFromPlanForNonApiFields(planModel, stateModel)
 	// Update State finally for Plan
@@ -365,7 +365,7 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 }
 
 func (r *repositoryResource) updateRepository(ctx context.Context, planModel, stateModel any, respDiags *diag.Diagnostics) bool {
-	// Make API requet
+	// Make API request
 	httpResponse, err := r.RepositoryFormat.DoUpdateRequest(planModel, stateModel, r.Client, ctx)
 
 	// Handle any errors


### PR DESCRIPTION
When updating a repository, UpdateStateFromApi was called with the prior state instead of the plan. For apt_signing (sensitive value), this caused two issues:

1. The passphrase and key_pair were always restored from prior state, meaning changes to these values were silently ignored and state remained stale after apply.

2. When the values were changed, Terraform detected an inconsistency between the planned sensitive value and the value written to state, producing:

   "inconsistent values for sensitive attribute"

**Acceptance/Integration Tests:** not run.

Refs: [#397](https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/397)