### PR TITLE
fix: Ensure non-api returnable fields for `sonatyperepo_repository_apt_hosted` are mapped from Plan

### DIFF
--- a/.github/workflows/test-untrusted.yml
+++ b/.github/workflows/test-untrusted.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Run linters
               uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
               with:
-                  version: 2.10.1
+                  version: v2.10.1
 
     docs-check:
         name: Ensure Docs are Generated

--- a/.github/workflows/test-untrusted.yml
+++ b/.github/workflows/test-untrusted.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Run linters
               uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
               with:
-                  version: latest
+                  version: 2.10.1
 
     docs-check:
         name: Ensure Docs are Generated

--- a/internal/provider/model/repository_apt.go
+++ b/internal/provider/model/repository_apt.go
@@ -59,6 +59,14 @@ func (m *aptSigningModel) MapToApi(api *sonatyperepo.AptSigningRepositoriesAttri
 	api.Passphrase = m.Passphrase.ValueStringPointer()
 }
 
+func (m *aptSigningModel) MapMissingApiFieldsFromPlan(planModel aptSigningModel) {
+	m.Passphrase = planModel.Passphrase
+}
+
+func (m *RepositoryAptHostedModel) MapMissingApiFieldsFromPlan(planModel RepositoryAptHostedModel) {
+	m.AptSigning.MapMissingApiFieldsFromPlan(*planModel.AptSigning)
+}
+
 func (m *RepositoryAptHostedModel) FromApiModel(api sonatyperepo.AptHostedApiRepository) {
 	m.Name = types.StringPointerValue(api.Name)
 	m.Online = types.BoolValue(api.Online)

--- a/internal/provider/repository/format/apt.go
+++ b/internal/provider/repository/format/apt.go
@@ -145,6 +145,18 @@ func (f *AptRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any {
 	return stateModel
 }
 
+func (f *AptRepositoryFormatHosted) UpdateStateFromPlanForNonApiFields(plan, state any) any {
+	var planModel = (plan).(model.RepositoryAptHostedModel)
+	var stateModel model.RepositoryAptHostedModel
+	// During import, state might be nil, so we create a new model
+	if state != nil {
+		stateModel = (state).(model.RepositoryAptHostedModel)
+	}
+
+	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	return stateModel
+}
+
 // --------------------------------------------
 // PROXY APT Format Functions
 // --------------------------------------------


### PR DESCRIPTION
Resolves #397 