### PR TITLE
fix: Prevent "inconsistent apply" when using `Bearer` authentication `sonatyperepo_repository_[FORMAT]_proxy` resources

### DIFF
--- a/internal/provider/model/repository_proxy.go
+++ b/internal/provider/model/repository_proxy.go
@@ -222,9 +222,7 @@ func (m *RepositoryHttpClientAuthenticationModel) MapFromApiHttpClientConnection
 		m.Preemptive = types.BoolPointerValue(api.Preemptive)
 	}
 
-	if *api.Type == common.HTTP_AUTH_TYPE_BEARER_TOKEN {
-		m.BearerToken = types.StringPointerValue(api.BearerToken)
-	} else if api.Type != nil {
+	if api.Type != nil {
 		m.Username = types.StringPointerValue(api.Username)
 		// m.Password = types.StringPointerValue(api.Password)
 

--- a/internal/provider/model/repository_proxy.go
+++ b/internal/provider/model/repository_proxy.go
@@ -116,6 +116,9 @@ func (m *repositoryHttpClientModel) MapToApiHttpClientAttributesWithPreemptiveAu
 
 func (m *repositoryHttpClientModel) MapMissingApiFieldsFromPlan(planModel repositoryHttpClientModel) {
 	if planModel.Authentication != nil {
+		if m.Authentication == nil {
+			m.Authentication = &RepositoryHttpClientAuthenticationModel{}
+		}
 		m.Authentication.MapMissingApiFieldsFromPlan(planModel.Authentication)
 	}
 }
@@ -287,6 +290,7 @@ func (m *RepositoryHttpClientAuthenticationModel) MapToApiHttpClientConnectionAu
 
 func (m *RepositoryHttpClientAuthenticationModel) MapMissingApiFieldsFromPlan(planModel *RepositoryHttpClientAuthenticationModel) {
 	m.Password = planModel.Password
+	m.BearerToken = planModel.BearerToken
 	if !planModel.Preemptive.ValueBool() {
 		m.Preemptive = planModel.Preemptive
 	}

--- a/internal/provider/repository/huggingface/repository_huggingface_x_resource_test.go
+++ b/internal/provider/repository/huggingface/repository_huggingface_x_resource_test.go
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package huggingface_test
+
+import (
+	"fmt"
+	"testing"
+
+	"terraform-provider-sonatyperepo/internal/provider/common"
+	repotest "terraform-provider-sonatyperepo/internal/provider/repository/repotest"
+	utils_test "terraform-provider-sonatyperepo/internal/provider/utils"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	resourceTypeHuggingfaceProxy = "sonatyperepo_repository_huggingface_proxy"
+)
+
+var (
+	resourceHuggingfaceProxyName = fmt.Sprintf(utils_test.RES_NAME_FORMAT, resourceTypeHuggingfaceProxy)
+)
+
+// TestAccRepositoryHuggingfaceProxyWithBearerTokenAuth tests Issue #413
+// This test verifies that bearer_token authentication works correctly for HuggingFace proxy repositories.
+// The Nexus API does not return the bearer_token value after create/update, so the provider must
+// copy the value from the plan to the state to avoid "inconsistent values for sensitive attribute" errors.
+func TestAccRepositoryHuggingfaceProxyWithBearerTokenAuth(t *testing.T) {
+	randomString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	repoName := fmt.Sprintf("huggingface-proxy-bearer-%s", randomString)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create repository without authentication
+			{
+				Config: fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "repo" {
+  name = "%s"
+  online = true
+  storage = {
+    blob_store_name = "default"
+    strict_content_type_validation = true
+  }
+  proxy = {
+    remote_url = "https://huggingface.co"
+    content_max_age = 1440
+    metadata_max_age = 1440
+  }
+  negative_cache = {
+    enabled = true
+    time_to_live = 1440
+  }
+  http_client = {
+    blocked = false
+    auto_block = true
+  }
+}
+`, resourceTypeHuggingfaceProxy, repoName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_NAME, repoName),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_ONLINE, "true"),
+					resource.TestCheckResourceAttrSet(resourceHuggingfaceProxyName, repotest.RES_ATTR_URL),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_PROXY_REMOTE_URL, "https://huggingface.co"),
+					resource.TestCheckNoResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_HTTP_CLIENT_AUTHENTICATION),
+				),
+			},
+			// Step 2: Update to add bearer token authentication - this is where Issue #413 manifests
+			{
+				Config: fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "repo" {
+  name = "%s"
+  online = true
+  storage = {
+    blob_store_name = "default"
+    strict_content_type_validation = true
+  }
+  proxy = {
+    remote_url = "https://huggingface.co"
+    content_max_age = 1440
+    metadata_max_age = 1440
+  }
+  negative_cache = {
+    enabled = true
+    time_to_live = 1440
+  }
+  http_client = {
+    blocked = false
+    auto_block = true
+    authentication = {
+      type = "bearerToken"
+      bearer_token = "test-bearer-token-value"
+    }
+  }
+}
+`, resourceTypeHuggingfaceProxy, repoName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_NAME, repoName),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_ONLINE, "true"),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_HTTP_CLIENT_AUTHENTICATION_TYPE, common.HTTP_AUTH_TYPE_BEARER_TOKEN),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_HTTP_CLIENT_AUTHENTICATION_BEARER_TOKEN, "test-bearer-token-value"),
+				),
+			},
+			// Step 3: Update bearer token value - verify it persists correctly
+			{
+				Config: fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "repo" {
+  name = "%s"
+  online = true
+  storage = {
+    blob_store_name = "default"
+    strict_content_type_validation = true
+  }
+  proxy = {
+    remote_url = "https://huggingface.co"
+    content_max_age = 1440
+    metadata_max_age = 1440
+  }
+  negative_cache = {
+    enabled = true
+    time_to_live = 1440
+  }
+  http_client = {
+    blocked = false
+    auto_block = true
+    authentication = {
+      type = "bearerToken"
+      bearer_token = "updated-bearer-token-value"
+    }
+  }
+}
+`, resourceTypeHuggingfaceProxy, repoName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_NAME, repoName),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_HTTP_CLIENT_AUTHENTICATION_BEARER_TOKEN, "updated-bearer-token-value"),
+				),
+			},
+			// Step 4: Remove authentication - verify clean removal
+			{
+				Config: fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "repo" {
+  name = "%s"
+  online = true
+  storage = {
+    blob_store_name = "default"
+    strict_content_type_validation = true
+  }
+  proxy = {
+    remote_url = "https://huggingface.co"
+    content_max_age = 1440
+    metadata_max_age = 1440
+  }
+  negative_cache = {
+    enabled = true
+    time_to_live = 1440
+  }
+  http_client = {
+    blocked = false
+    auto_block = true
+  }
+}
+`, resourceTypeHuggingfaceProxy, repoName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_NAME, repoName),
+					resource.TestCheckNoResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_HTTP_CLIENT_AUTHENTICATION),
+				),
+			},
+		},
+	})
+}
+
+// TestAccRepositoryHuggingfaceProxyWithBearerTokenAuthFromCreate tests creating a repository
+// with bearer token authentication from the start (not adding it later).
+func TestAccRepositoryHuggingfaceProxyWithBearerTokenAuthFromCreate(t *testing.T) {
+	randomString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	repoName := fmt.Sprintf("huggingface-proxy-bearer-create-%s", randomString)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with bearer token authentication from the start
+			{
+				Config: fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "repo" {
+  name = "%s"
+  online = true
+  storage = {
+    blob_store_name = "default"
+    strict_content_type_validation = true
+  }
+  proxy = {
+    remote_url = "https://huggingface.co"
+    content_max_age = 1440
+    metadata_max_age = 1440
+  }
+  negative_cache = {
+    enabled = true
+    time_to_live = 1440
+  }
+  http_client = {
+    blocked = false
+    auto_block = true
+    authentication = {
+      type = "bearerToken"
+      bearer_token = "initial-bearer-token"
+    }
+  }
+}
+`, resourceTypeHuggingfaceProxy, repoName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_NAME, repoName),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_ONLINE, "true"),
+					resource.TestCheckResourceAttrSet(resourceHuggingfaceProxyName, repotest.RES_ATTR_URL),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_PROXY_REMOTE_URL, "https://huggingface.co"),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_HTTP_CLIENT_AUTHENTICATION_TYPE, common.HTTP_AUTH_TYPE_BEARER_TOKEN),
+					resource.TestCheckResourceAttr(resourceHuggingfaceProxyName, repotest.RES_ATTR_HTTP_CLIENT_AUTHENTICATION_BEARER_TOKEN, "initial-bearer-token"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/repository/huggingface/repository_huggingface_x_resource_test.go
+++ b/internal/provider/repository/huggingface/repository_huggingface_x_resource_test.go
@@ -218,6 +218,7 @@ resource "%s" "repo" {
     authentication = {
       type = "bearerToken"
       bearer_token = "initial-bearer-token"
+      preemptive = false
     }
   }
 }

--- a/internal/provider/repository/repository_common.go
+++ b/internal/provider/repository/repository_common.go
@@ -101,6 +101,8 @@ func (r *repositoryResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Map to state
 	stateModel := r.RepositoryFormat.UpdateStateFromApi(plan, apiResponse)
+	// Copy various fields not returned by a READ from Plan (e.g., sensitive auth fields)
+	stateModel = r.RepositoryFormat.UpdateStateFromPlanForNonApiFields(plan, stateModel)
 	stateModel = r.RepositoryFormat.UpdatePlanForState(stateModel)
 
 	// Configure firewall if needed

--- a/internal/provider/repository/repotest/constants.go
+++ b/internal/provider/repository/repotest/constants.go
@@ -46,6 +46,7 @@ const (
 	RES_ATTR_HTTP_CLIENT_AUTHENTICATION_PREMPTIVE             string = "http_client.authentication.preemptive"
 	RES_ATTR_HTTP_CLIENT_AUTHENTICATION_TYPE                  string = "http_client.authentication.type"
 	RES_ATTR_HTTP_CLIENT_AUTHENTICATION_USERNAME              string = "http_client.authentication.username"
+	RES_ATTR_HTTP_CLIENT_AUTHENTICATION_BEARER_TOKEN          string = "http_client.authentication.bearer_token"
 	RES_ATTR_HTTP_CLIENT_CONNECTION_ENABLE_CIRCULAR_REDIRECTS string = "http_client.connection.enable_circular_redirects"
 	RES_ATTR_HTTP_CLIENT_CONNECTION_ENABLE_COOKIES            string = "http_client.connection.enable_cookies"
 	RES_ATTR_HTTP_CLIENT_CONNECTION_USE_TRUST_STORE           string = "http_client.connection.use_trust_store"


### PR DESCRIPTION
Resolves #413 