### PR TITLE
fix: Correct http_client.connection in ansiblegalaxy_proxy example 

### DIFF
--- a/docs/resources/repository_ansiblegalaxy_proxy.md
+++ b/docs/resources/repository_ansiblegalaxy_proxy.md
@@ -34,14 +34,16 @@ resource "sonatyperepo_repository_ansiblegalaxy_proxy" "ansiblegalaxy_proxy" {
   }
 
   http_client = {
-    blocked                   = false
-    auto_block                = false
-    connection                = "0"
-    enable_circular_redirects = true
-    enable_cookies            = true
-    retries                   = 0
-    timeout                   = 60
-    use_trust_store           = false
+    blocked    = false
+    auto_block = true
+
+    connection = {
+      enable_circular_redirects = true
+      enable_cookies            = true
+      retries                   = 3
+      timeout                   = 60
+      use_trust_store           = false
+    }
   }
 }
 ```

--- a/examples/resources/sonatyperepo_repository_ansiblegalaxy_proxy/resource.tf
+++ b/examples/resources/sonatyperepo_repository_ansiblegalaxy_proxy/resource.tf
@@ -19,13 +19,15 @@ resource "sonatyperepo_repository_ansiblegalaxy_proxy" "ansiblegalaxy_proxy" {
   }
 
   http_client = {
-    blocked                   = false
-    auto_block                = false
-    connection                = "0"
-    enable_circular_redirects = true
-    enable_cookies            = true
-    retries                   = 0
-    timeout                   = 60
-    use_trust_store           = false
+    blocked    = false
+    auto_block = true
+
+    connection = {
+      enable_circular_redirects = true
+      enable_cookies            = true
+      retries                   = 3
+      timeout                   = 60
+      use_trust_store           = false
+    }
   }
 }


### PR DESCRIPTION
The example introduced in #429 used a flat `connection = "0"` and flat connection sub-attributes on `http_client`, which fails on apply: `attribute "connection": object required, but have string`.

`http_client.connection` is a nested object — corrected the example and regenerated the documentation.