### PR TITLE
feat: Add support for NXRM 3.95.x (and 3.94.x) via multi-version API client re-architecture

### DIFF
--- a/.github/workflows/test-trusted-ha-cluster.yml
+++ b/.github/workflows/test-trusted-ha-cluster.yml
@@ -41,7 +41,7 @@ jobs:
             matrix:
                 nxrm:
                     - '3.89.1-02' # First version tested HA against
-                    - '3.95.0-07' # LATEST
+                    - '3.95.1-01' # LATEST
                 terraform:
                     # - '1.14.*'
                     - '1.15.*' # Latest
@@ -290,28 +290,28 @@ jobs:
 
             - name: Store nexus.log (Node 1)
               if: success() || failure()
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                 name: "nexus-node-01.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
                 path: "${{ github.workspace }}/node-01/sonatype-work/nexus3/log/nexus.log"
 
             - name: Store nexus.log (Node 2)
               if: success() || failure()
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                 name: "nexus-node-02.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
                 path: "${{ github.workspace }}/node-02/sonatype-work/nexus3/log/nexus.log"
 
             - name: Store nexus.log (Node 3)
               if: success() || failure()
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                 name: "nexus-node-03.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
                 path: "${{ github.workspace }}/node-03/sonatype-work/nexus3/log/nexus.log"
 
             - name: Store nginx access log
               if: success() || failure()
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                 name: "nginx-access.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
                 path: "/var/log/nginx/access.log"

--- a/.github/workflows/test-trusted-ha-cluster.yml
+++ b/.github/workflows/test-trusted-ha-cluster.yml
@@ -41,7 +41,7 @@ jobs:
             matrix:
                 nxrm:
                     - '3.89.1-02' # First version tested HA against
-                    - '3.93.0-06' # LATEST
+                    - '3.95.0-07' # LATEST
                 terraform:
                     # - '1.14.*'
                     - '1.15.*' # Latest

--- a/.github/workflows/test-trusted.yml
+++ b/.github/workflows/test-trusted.yml
@@ -83,7 +83,9 @@ jobs:
                     - '3.90.1-01'
                     - '3.91.0-07'
                     - '3.92.0-03'
-                    - '3.93.0-06' # LATEST
+                    - '3.93.0-06' 
+                    - '3.94.1-06'
+                    - '3.95.0-07' # LATEST
                 # list whatever Terraform versions here you would like to support
                 terraform:
                     - '1.7.*' # Minimum

--- a/.github/workflows/test-trusted.yml
+++ b/.github/workflows/test-trusted.yml
@@ -85,7 +85,7 @@ jobs:
                     - '3.92.0-03'
                     - '3.93.0-06' 
                     - '3.94.1-06'
-                    - '3.95.0-07' # LATEST
+                    - '3.95.1-01' # LATEST
                 # list whatever Terraform versions here you would like to support
                 terraform:
                     - '1.7.*' # Minimum
@@ -192,7 +192,7 @@ jobs:
 
             - name: Store nexus.log
               if: success() || failure()
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                 name: "nexus.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
                 path: "${{ github.workspace }}/sonatype-work/nexus3/log/nexus.log"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## UNRELEASED
 
-*TBC*
+BREAKING CHANGES:
+* `maven.layout_policy` and `maven.version_policy` on `sonatyperepo_repository_maven_hosted`/`sonatyperepo_repository_maven_proxy` are now `Required` (previously `Optional`) - Sonatype Nexus Repository rejects requests where these are omitted [GH-449]
+* `alpine.key_pair` on `sonatyperepo_repository_alpine_hosted`/`sonatyperepo_repository_alpine_proxy`/`sonatyperepo_repository_alpine_group` is now `Required` (previously `Optional`) - Sonatype Nexus Repository rejects requests where this is omitted or empty [GH-449]
+
+ENHANCEMENTS:
+* Added support for Sonatype Nexus Repository 3.95.x, alongside continued support for pre-3.94.0 versions [GH-449]
+* `yum.deploy_policy` on `sonatyperepo_repository_yum_hosted` now defaults to `STRICT` when not specified, matching the Sonatype Nexus Repository UI default [GH-449]
 
 ## 1.14.0 Aug 05, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 ## UNRELEASED
 
-BREAKING CHANGES:
-* `maven.layout_policy` and `maven.version_policy` on `sonatyperepo_repository_maven_hosted`/`sonatyperepo_repository_maven_proxy` are now `Required` (previously `Optional`) - Sonatype Nexus Repository rejects requests where these are omitted [GH-449]
-* `alpine.key_pair` on `sonatyperepo_repository_alpine_hosted`/`sonatyperepo_repository_alpine_proxy`/`sonatyperepo_repository_alpine_group` is now `Required` (previously `Optional`) - Sonatype Nexus Repository rejects requests where this is omitted or empty [GH-449]
-
 ENHANCEMENTS:
-* Added support for Sonatype Nexus Repository 3.95.x, alongside continued support for pre-3.94.0 versions [GH-449]
-* `yum.deploy_policy` on `sonatyperepo_repository_yum_hosted` now defaults to `STRICT` when not specified, matching the Sonatype Nexus Repository UI default [GH-449]
+* Added support for Sonatype Nexus Repository 3.94.x and 3.95.x, alongside continued support for pre-3.94.0 versions [GH-449], [GH-445]
+
+BUG FIXES:
+* `maven.layout_policy` and `maven.version_policy` on `sonatyperepo_repository_maven_hosted`/`sonatyperepo_repository_maven_proxy` are now `Required` (previously `Optional`) - Sonatype Nexus Repository rejects requests where these are omitted
+* `alpine.key_pair` on `sonatyperepo_repository_alpine_hosted`/`sonatyperepo_repository_alpine_proxy`/`sonatyperepo_repository_alpine_group` is now `Required` (previously `Optional`) - Sonatype Nexus Repository rejects requests where this is omitted or empty
+* `yum.deploy_policy` on `sonatyperepo_repository_yum_hosted` now defaults to `STRICT` when not specified, matching the Sonatype Nexus Repository UI default
+
+NOTES:
+* Tested against [Sonatype Nexus Repository Manager 3.95.1](https://help.sonatype.com/en/sonatype-nexus-repository-3-92-0-release-notes.html) [GH-449]
+* Tested against [Sonatype Nexus Repository Manager 3.94.0](https://help.sonatype.com/en/sonatype-nexus-repository-3-92-0-release-notes.html) [GH-445]
+* Dependency updates
 
 ## 1.14.0 Aug 05, 2026
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [Sonatype Nexus Repository 3 Versions Status](https://help.sonatype.com/en/s
 
 ### Terraform Version support
 
-We test on the latest patch release of each the earliest and latest version of Terraform i.e. `1.7.x` and  `1.14.x` - i.e. we aim to support all Terraform versions since `1.7.0` (earlier verions may also work, but are not tested and bugs will not be actioned if they are proven to affect these earlier versions).
+We test on the latest patch release of each the earliest and latest version of Terraform i.e. `1.7.x` and  `1.15.x` - i.e. we aim to support all Terraform versions since `1.7.0` (earlier verions may also work, but are not tested and bugs will not be actioned if they are proven to affect these earlier versions).
 
 ## Usage
 
@@ -62,9 +62,9 @@ Phew, that was easier than I thought. Last but not least of all - have fun!
 [shield_tfr-version]: https://img.shields.io/badge/Terraform%20Registry-v1.14.0-8A2BE2
 [shield_license]: https://img.shields.io/github/license/sonatype-nexus-community/terraform-provider-sonatyperepo?logo=open%20source%20initiative&logoColor=white "license"
 [shield_tf_version]: https://img.shields.io/badge/Terraform-1.7.0&nbsp;&ndash;&nbsp;1.15.x-blue
-[shield_nxrm_version]: https://img.shields.io/badge/Sonatype_Nexus_Repository-3.82.0&nbsp;&ndash;&nbsp;3.93.0-blue
+[shield_nxrm_version]: https://img.shields.io/badge/Sonatype_Nexus_Repository-3.82.0&nbsp;&ndash;&nbsp;3.95.1-blue
 
 [link_tfr]: https://registry.terraform.io/providers/sonatype-nexus-community/sonatyperepo/latest
 [link_gh-workflow-test]: https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/actions/workflows/test-trusted.yml?query=branch%3Amain
 [license_file]: https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/blob/main/LICENSE
-[link_nxrm_release]: https://help.sonatype.com/en/sonatype-nexus-repository-3-93-0-release-notes.html
+[link_nxrm_release]: https://help.sonatype.com/en/sonatype-nexus-repository-3-95-0-release-notes.html

--- a/docs/resources/repository_alpine_group.md
+++ b/docs/resources/repository_alpine_group.md
@@ -76,9 +76,12 @@ Required:
 <a id="nestedatt--alpine"></a>
 ### Nested Schema for `alpine`
 
-Optional:
+Required:
 
 - `key_pair` (String) RSA private key in PEM format used to sign the repository index
+
+Optional:
+
 - `passphrase` (String, Sensitive) Passphrase to access the RSA signing key
 
 

--- a/docs/resources/repository_alpine_hosted.md
+++ b/docs/resources/repository_alpine_hosted.md
@@ -62,9 +62,12 @@ Required:
 <a id="nestedatt--alpine"></a>
 ### Nested Schema for `alpine`
 
-Optional:
+Required:
 
 - `key_pair` (String) RSA private key in PEM format used to sign the repository index
+
+Optional:
+
 - `passphrase` (String, Sensitive) Passphrase to access the RSA signing key
 
 

--- a/docs/resources/repository_alpine_proxy.md
+++ b/docs/resources/repository_alpine_proxy.md
@@ -154,9 +154,12 @@ Required:
 <a id="nestedatt--alpine"></a>
 ### Nested Schema for `alpine`
 
-Optional:
+Required:
 
 - `key_pair` (String) RSA private key in PEM format used to sign the repository index
+
+Optional:
+
 - `passphrase` (String, Sensitive) Passphrase to access the RSA signing key
 
 

--- a/docs/resources/repository_maven2_hosted.md
+++ b/docs/resources/repository_maven2_hosted.md
@@ -53,11 +53,14 @@ resource "sonatyperepo_repository_maven2_hosted" "maven_hosted" {
 <a id="nestedatt--maven"></a>
 ### Nested Schema for `maven`
 
+Required:
+
+- `layout_policy` (String) Validate that all paths are maven artifact or metadata paths
+- `version_policy` (String) What type of artifacts does this repository store?
+
 Optional:
 
 - `content_disposition` (String) Add Content-Disposition header as 'ATTACHMENT' to disable some content from being inline in a browser.
-- `layout_policy` (String) Validate that all paths are maven artifact or metadata paths
-- `version_policy` (String) What type of artifacts does this repository store?
 
 
 <a id="nestedatt--storage"></a>

--- a/docs/resources/repository_maven2_proxy.md
+++ b/docs/resources/repository_maven2_proxy.md
@@ -123,11 +123,14 @@ Optional:
 <a id="nestedatt--maven"></a>
 ### Nested Schema for `maven`
 
+Required:
+
+- `layout_policy` (String) Validate that all paths are maven artifact or metadata paths
+- `version_policy` (String) What type of artifacts does this repository store?
+
 Optional:
 
 - `content_disposition` (String) Add Content-Disposition header as 'ATTACHMENT' to disable some content from being inline in a browser.
-- `layout_policy` (String) Validate that all paths are maven artifact or metadata paths
-- `version_policy` (String) What type of artifacts does this repository store?
 
 
 <a id="nestedatt--negative_cache"></a>

--- a/docs/resources/repository_maven_hosted.md
+++ b/docs/resources/repository_maven_hosted.md
@@ -35,11 +35,14 @@ description: |-
 <a id="nestedatt--maven"></a>
 ### Nested Schema for `maven`
 
+Required:
+
+- `layout_policy` (String) Validate that all paths are maven artifact or metadata paths
+- `version_policy` (String) What type of artifacts does this repository store?
+
 Optional:
 
 - `content_disposition` (String) Add Content-Disposition header as 'ATTACHMENT' to disable some content from being inline in a browser.
-- `layout_policy` (String) Validate that all paths are maven artifact or metadata paths
-- `version_policy` (String) What type of artifacts does this repository store?
 
 
 <a id="nestedatt--storage"></a>

--- a/docs/resources/repository_maven_proxy.md
+++ b/docs/resources/repository_maven_proxy.md
@@ -83,11 +83,14 @@ Optional:
 <a id="nestedatt--maven"></a>
 ### Nested Schema for `maven`
 
+Required:
+
+- `layout_policy` (String) Validate that all paths are maven artifact or metadata paths
+- `version_policy` (String) What type of artifacts does this repository store?
+
 Optional:
 
 - `content_disposition` (String) Add Content-Disposition header as 'ATTACHMENT' to disable some content from being inline in a browser.
-- `layout_policy` (String) Validate that all paths are maven artifact or metadata paths
-- `version_policy` (String) What type of artifacts does this repository store?
 
 
 <a id="nestedatt--negative_cache"></a>

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
 	github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3 v3.93.2
+	github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.0
 	github.com/sonatype-nexus-community/terraform-provider-shared v0.9.4
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/text v0.39.0
@@ -67,5 +68,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/validator.v2 v2.0.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-sonatyperepo
 
-go 1.25.0
+go 1.25.13
 
 require (
 	github.com/hashicorp/go-version v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3 v3.93.2 h1:pkLD4Z/oEPth5nlBpWOaXGX+SP89bJLTinoK1p4Jvi4=
 github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3 v3.93.2/go.mod h1:aflMwOI/XkRO3HuXgCVlh+zPFj9KVkDtE1ZwWqJeCm0=
+github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.0 h1:bVr5N4o5dbaA/TVVZKCeAD8etImIgz5b2u9UVKTonbM=
+github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.0/go.mod h1:aa2xZDktuLQ1yLRaVgd8OE7RCf281zYbGN9HPhhjxEg=
 github.com/sonatype-nexus-community/terraform-provider-shared v0.9.4 h1:U7pdTOdwl/RS+5Zvz7mUE01XrS5ntONzxD9OmN6ymJw=
 github.com/sonatype-nexus-community/terraform-provider-shared v0.9.4/go.mod h1:WMs2zRL3dPwQj1A9As16dLzVs9jRFJKEHOtNfKeZqjM=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -723,6 +725,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
+gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/provider/blob_store/blob_store_acs_data_source.go
+++ b/internal/provider/blob_store/blob_store_acs_data_source.go
@@ -86,7 +86,7 @@ func (d *acsBlobStoreDataSource) Read(ctx context.Context, req datasource.ReadRe
 	}
 
 	// Call API
-	apiResponse, httpResponse, err := d.Client.BlobStoreAPI.GetBlobStore1(d.AuthContext(ctx), data.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := d.Services.BlobStore.GetBlobStore1(d.AuthContext(ctx), data.Name.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusNotFound {

--- a/internal/provider/blob_store/blob_store_acs_resource.go
+++ b/internal/provider/blob_store/blob_store_acs_resource.go
@@ -107,7 +107,7 @@ func (r *blobStoreAcsResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Call API to Create
-	httpResponse, err := r.Client.BlobStoreAPI.CreateBlobStore1(r.AuthContext(ctx)).Body(*plan.MapToApi()).Execute()
+	httpResponse, err := r.Services.BlobStore.CreateBlobStore1(r.AuthContext(ctx), *plan.MapToApi())
 
 	// Handle Error
 	if err != nil {
@@ -192,7 +192,7 @@ func (r *blobStoreAcsResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	// Call API to Update
-	httpResponse, err := r.Client.BlobStoreAPI.UpdateBlobStore1(r.AuthContext(ctx), state.Name.ValueString()).Body(*plan.MapToApi()).Execute()
+	httpResponse, err := r.Services.BlobStore.UpdateBlobStore1(r.AuthContext(ctx), state.Name.ValueString(), *plan.MapToApi())
 
 	// Handle Error
 	if err != nil {
@@ -256,7 +256,7 @@ func (r *blobStoreAcsResource) ImportState(ctx context.Context, req resource.Imp
 
 func (r *blobStoreAcsResource) readAcsBlobStore(ctx context.Context, blobStoreName string, respDiagnostics *diag.Diagnostics, respState *tfsdk.State) *sonatyperepo.AzureBlobStoreApiModel {
 	// Call Read API
-	apiResponse, httpResponse, err := r.Client.BlobStoreAPI.GetBlobStore1(r.AuthContext(ctx), blobStoreName).Execute()
+	apiResponse, httpResponse, err := r.Services.BlobStore.GetBlobStore1(r.AuthContext(ctx), blobStoreName)
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusNotFound {

--- a/internal/provider/blob_store/blob_store_file_data_source.go
+++ b/internal/provider/blob_store/blob_store_file_data_source.go
@@ -83,7 +83,7 @@ func (d *fileBlobStoreDataSource) Read(ctx context.Context, req datasource.ReadR
 
 	ctx = d.AuthContext(ctx)
 
-	blobStore, httpResponse, err := d.Client.BlobStoreAPI.GetFileBlobStoreConfiguration(ctx, data.Name.ValueString()).Execute()
+	blobStore, httpResponse, err := d.Services.BlobStore.GetFileBlobStoreConfiguration(ctx, data.Name.ValueString())
 	if err != nil {
 		errors.HandleAPIError(
 			common.ERROR_UNABLE_TO_READ_BLOB_STORE_FILE,

--- a/internal/provider/blob_store/blob_store_file_resource.go
+++ b/internal/provider/blob_store/blob_store_file_resource.go
@@ -95,8 +95,7 @@ func (r *blobStoreFileResource) Create(ctx context.Context, req resource.CreateR
 		}
 	}
 
-	create_request := r.Client.BlobStoreAPI.CreateFileBlobStore(ctx).Body(request_payload)
-	api_response, err := create_request.Execute()
+	api_response, err := r.Services.BlobStore.CreateFileBlobStore(ctx, request_payload)
 
 	// Handle Error
 	if err != nil {
@@ -141,7 +140,7 @@ func (r *blobStoreFileResource) Read(ctx context.Context, req resource.ReadReque
 	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	blobStoreApiResponse, httpResponse, err := r.Client.BlobStoreAPI.GetFileBlobStoreConfiguration(ctx, state.Name.ValueString()).Execute()
+	blobStoreApiResponse, httpResponse, err := r.Services.BlobStore.GetFileBlobStoreConfiguration(ctx, state.Name.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == 404 {
@@ -211,10 +210,8 @@ func (r *blobStoreFileResource) Update(ctx context.Context, req resource.UpdateR
 			Type:  plan.SoftQuota.Type.ValueStringPointer(),
 		}
 	}
-	apiUpdateRequest := r.Client.BlobStoreAPI.UpdateFileBlobStore(ctx, state.Name.ValueString()).Body(request_payload)
-
 	// Call API
-	httpResponse, err := apiUpdateRequest.Execute()
+	httpResponse, err := r.Services.BlobStore.UpdateFileBlobStore(ctx, state.Name.ValueString(), request_payload)
 
 	// Handle Error(s)
 	if err != nil {
@@ -258,11 +255,7 @@ func (r *blobStoreFileResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Delete API Call
 	DeleteBlobStore(r.Client, &ctx, state.Name.ValueString(), resp)

--- a/internal/provider/blob_store/blob_store_google_cloud_resource.go
+++ b/internal/provider/blob_store/blob_store_google_cloud_resource.go
@@ -150,7 +150,7 @@ func (r *blobStoreGoogleCloudResource) Create(ctx context.Context, req resource.
 	ctx = r.AuthContext(ctx)
 
 	requestPayload := r.buildRequestPayload(ctx, &plan, "create")
-	apiResponse, err := r.Client.BlobStoreAPI.CreateBlobStore2(ctx).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.BlobStore.CreateBlobStore2(ctx, requestPayload)
 
 	if err != nil {
 		errors.HandleAPIError(
@@ -191,7 +191,7 @@ func (r *blobStoreGoogleCloudResource) Read(ctx context.Context, req resource.Re
 
 	ctx = r.AuthContext(ctx)
 
-	apiResponse, httpResponse, err := r.Client.BlobStoreAPI.GetBlobStore2(ctx, state.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := r.Services.BlobStore.GetBlobStore2(ctx, state.Name.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == 404 {
@@ -239,7 +239,7 @@ func (r *blobStoreGoogleCloudResource) Update(ctx context.Context, req resource.
 	ctx = r.AuthContext(ctx)
 
 	requestPayload := r.buildRequestPayload(ctx, &plan, "update")
-	apiResponse, err := r.Client.BlobStoreAPI.UpdateBlobStore2(ctx, state.Name.ValueString()).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.BlobStore.UpdateBlobStore2(ctx, state.Name.ValueString(), requestPayload)
 
 	if err != nil {
 		if apiResponse.StatusCode == 404 {

--- a/internal/provider/blob_store/blob_store_group_data_source.go
+++ b/internal/provider/blob_store/blob_store_group_data_source.go
@@ -89,7 +89,7 @@ func (d *groupBlobStoreDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	apiResponse, httpResponse, err := d.Client.BlobStoreAPI.GetGroupBlobStoreConfiguration(ctx, data.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := d.Services.BlobStore.GetGroupBlobStoreConfiguration(ctx, data.Name.ValueString())
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable to read group blob store",

--- a/internal/provider/blob_store/blob_store_group_resource.go
+++ b/internal/provider/blob_store/blob_store_group_resource.go
@@ -91,7 +91,7 @@ func (r *blobStoreGroupResource) Create(ctx context.Context, req resource.Create
 	ctx = r.AuthContext(ctx)
 	apiBody := sonatyperepo.NewGroupBlobStoreApiCreateRequestWithDefaults()
 	plan.MapToApiCreate(apiBody)
-	httpResponse, err := r.Client.BlobStoreAPI.CreateGroupBlobStore(ctx).Body(*apiBody).Execute()
+	httpResponse, err := r.Services.BlobStore.CreateGroupBlobStore(ctx, *apiBody)
 
 	if err != nil {
 		errors.HandleAPIError(
@@ -132,7 +132,7 @@ func (r *blobStoreGroupResource) Read(ctx context.Context, req resource.ReadRequ
 
 	// Call API to Create
 	ctx = r.AuthContext(ctx)
-	apiResponse, httpResponse, err := r.Client.BlobStoreAPI.GetGroupBlobStoreConfiguration(ctx, state.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := r.Services.BlobStore.GetGroupBlobStoreConfiguration(ctx, state.Name.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusNotFound {
@@ -183,7 +183,7 @@ func (r *blobStoreGroupResource) Update(ctx context.Context, req resource.Update
 	ctx = r.AuthContext(ctx)
 	apiBody := sonatyperepo.NewGroupBlobStoreApiUpdateRequestWithDefaults()
 	plan.MapToApiUpdate(apiBody)
-	httpResponse, err := r.Client.BlobStoreAPI.UpdateGroupBlobStore(ctx, state.Name.ValueString()).Body(*apiBody).Execute()
+	httpResponse, err := r.Services.BlobStore.UpdateGroupBlobStore(ctx, state.Name.ValueString(), *apiBody)
 
 	if err != nil {
 		errors.HandleAPIError(

--- a/internal/provider/blob_store/blob_store_s3_data_source.go
+++ b/internal/provider/blob_store/blob_store_s3_data_source.go
@@ -109,7 +109,7 @@ func (d *s3BlobStoreDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	apiResponse, httpResponse, err := d.Client.BlobStoreAPI.GetS3BlobStore(ctx, data.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := d.Services.BlobStore.GetS3BlobStore(ctx, data.Name.ValueString())
 	if err != nil {
 		errors.HandleAPIError(
 			fmt.Sprintf("No S3 BlobStore with name: %s", data.Name.ValueString()),

--- a/internal/provider/blob_store/blob_store_s3_resource.go
+++ b/internal/provider/blob_store/blob_store_s3_resource.go
@@ -158,7 +158,7 @@ func (r *blobStoreS3Resource) Create(ctx context.Context, req resource.CreateReq
 
 	apiBody := sonatyperepo.NewS3BlobStoreApiModelWithDefaults()
 	plan.MapToApi(apiBody)
-	httpResponse, err := r.Client.BlobStoreAPI.CreateS3BlobStore(ctx).Body(*apiBody).Execute()
+	httpResponse, err := r.Services.BlobStore.CreateS3BlobStore(ctx, *apiBody)
 
 	// Handle Error
 	if err != nil {
@@ -183,7 +183,7 @@ func (r *blobStoreS3Resource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.BlobStoreAPI.GetS3BlobStore(ctx, plan.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := r.Services.BlobStore.GetS3BlobStore(ctx, plan.Name.ValueString())
 
 	if err != nil || httpResponse.StatusCode != http.StatusOK {
 		if httpResponse.StatusCode == http.StatusNotFound {
@@ -235,7 +235,7 @@ func (r *blobStoreS3Resource) Read(ctx context.Context, req resource.ReadRequest
 	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.BlobStoreAPI.GetS3BlobStore(ctx, state.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := r.Services.BlobStore.GetS3BlobStore(ctx, state.Name.ValueString())
 
 	if err != nil || httpResponse.StatusCode != http.StatusOK {
 		if httpResponse.StatusCode == http.StatusNotFound {
@@ -291,7 +291,7 @@ func (r *blobStoreS3Resource) Update(ctx context.Context, req resource.UpdateReq
 	plan.MapToApi(apiBody)
 
 	// Call API
-	apiResponse, err := r.Client.BlobStoreAPI.UpdateS3BlobStore(ctx, state.Name.ValueString()).Body(*apiBody).Execute()
+	apiResponse, err := r.Services.BlobStore.UpdateS3BlobStore(ctx, state.Name.ValueString(), *apiBody)
 
 	// Handle Error(s)
 	if err != nil || apiResponse.StatusCode != http.StatusNoContent {
@@ -336,11 +336,7 @@ func (r *blobStoreS3Resource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Delete API Call
 	DeleteBlobStore(r.Client, &ctx, state.Name.ValueString(), resp)

--- a/internal/provider/blob_store/blob_stores_data_source.go
+++ b/internal/provider/blob_store/blob_stores_data_source.go
@@ -27,8 +27,6 @@ import (
 	sharederr "github.com/sonatype-nexus-community/terraform-provider-shared/errors"
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
-
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
 )
@@ -87,13 +85,9 @@ func (d *blobStoresDataSource) Schema(_ context.Context, req datasource.SchemaRe
 func (d *blobStoresDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state model.BlobStoresModel
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	blobStores, httpResponse, err := d.Client.BlobStoreAPI.ListBlobStores(ctx).Execute()
+	blobStores, httpResponse, err := d.Services.BlobStore.ListBlobStores(ctx)
 	if err != nil {
 		sharederr.HandleAPIError(
 			"Unable to Read Blob Stores",

--- a/internal/provider/capability/capabilities_data_source.go
+++ b/internal/provider/capability/capabilities_data_source.go
@@ -81,7 +81,7 @@ func (d *capabilitiesDataSource) Read(ctx context.Context, req datasource.ReadRe
 
 	ctx = d.AuthContext(ctx)
 
-	apiResponse, httpResponse, err := d.Client.CapabilitiesAPI.List2(ctx).Execute()
+	apiResponse, httpResponse, err := d.Services.Capability.List(ctx)
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable to list Capabilities",

--- a/internal/provider/capability/capability_common.go
+++ b/internal/provider/capability/capability_common.go
@@ -82,7 +82,7 @@ func (c *capabilityResource) Create(ctx context.Context, req resource.CreateRequ
 	ctx = c.AuthContext(ctx)
 
 	// Make API requet
-	capabilityCreateResponse, httpResponse, err := c.CapabilityType.DoCreateRequest(plan, c.Client, ctx, c.NxrmVersion)
+	capabilityCreateResponse, httpResponse, err := c.CapabilityType.DoCreateRequest(plan, c.Services.Capability, ctx, c.NxrmVersion)
 
 	// Handle Errors
 	if err != nil {
@@ -204,7 +204,7 @@ func (c *capabilityResource) Update(ctx context.Context, req resource.UpdateRequ
 	if shouldReturn {
 		return
 	}
-	httpResponse, err := c.CapabilityType.DoUpdateRequest(planModel, capabilityId.ValueString(), c.Client, ctx, c.NxrmVersion)
+	httpResponse, err := c.CapabilityType.DoUpdateRequest(planModel, capabilityId.ValueString(), c.Services.Capability, ctx, c.NxrmVersion)
 
 	// Handle any errors
 	if err != nil {
@@ -316,7 +316,7 @@ func (c *capabilityResource) Delete(ctx context.Context, req resource.DeleteRequ
 	success := false
 
 	for !success && attempts < maxAttempts {
-		httpResponse, err := c.Client.CapabilitiesAPI.Delete5(ctx, capabilityId.ValueString()).Execute()
+		httpResponse, err := c.Services.Capability.Delete(ctx, capabilityId.ValueString())
 
 		// Trap 500 Error as they occur when Repo is not in appropriate internal state
 		if httpResponse.StatusCode == http.StatusInternalServerError {
@@ -489,7 +489,7 @@ func (c *capabilityResource) readCapabilityById(capabilityId string, ctx context
 	ctx = c.AuthContext(ctx)
 
 	// Make API Request
-	apiResponse, httpResponse, err := c.Client.CapabilitiesAPI.List2(ctx).Execute()
+	apiResponse, httpResponse, err := c.Services.Capability.List(ctx)
 
 	// Handle any errors
 	if err != nil {

--- a/internal/provider/capability/capability_type/audit.go
+++ b/internal/provider/capability/capability_type/audit.go
@@ -49,21 +49,21 @@ func NewNewAuditCapability() *AuditCapability {
 // --------------------------------------------
 // Capabiltiy Type: Audit Functions
 // --------------------------------------------
-func (f *AuditCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *AuditCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityAuditModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *AuditCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *AuditCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityAuditModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *AuditCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/base_url.go
+++ b/internal/provider/capability/capability_type/base_url.go
@@ -52,21 +52,21 @@ func NewCoreBaseUrlCapability() *BaseUrlCapability {
 // --------------------------------------------
 // Capabiltiy Type: Base URL Functions
 // --------------------------------------------
-func (f *BaseUrlCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *BaseUrlCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCoreBaseUrlModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *BaseUrlCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *BaseUrlCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCoreBaseUrlModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *BaseUrlCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/common.go
+++ b/internal/provider/capability/capability_type/common.go
@@ -78,8 +78,8 @@ func (ct *BaseCapabilityType) DeprecationMessage() *string {
 // CapabilityTypeI that all Capability Types must implement
 // --------------------------------------------
 type CapabilityTypeI interface {
-	DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error)
-	DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error)
+	DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error)
+	DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error)
 	ApiCreateSuccessResponseCodes() []int
 	GetMarkdownDescription() string
 	PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics)

--- a/internal/provider/capability/capability_type/custom_s3_regions.go
+++ b/internal/provider/capability/capability_type/custom_s3_regions.go
@@ -52,21 +52,21 @@ func NewCustomS3RegionsCapability() *CustomS3RegionsCapability {
 // --------------------------------------------
 // Capabiltiy Type: Custom S3 Regions Functions
 // --------------------------------------------
-func (f *CustomS3RegionsCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *CustomS3RegionsCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCustomS3RegionsModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *CustomS3RegionsCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *CustomS3RegionsCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCustomS3RegionsModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *CustomS3RegionsCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/default_role.go
+++ b/internal/provider/capability/capability_type/default_role.go
@@ -51,21 +51,21 @@ func NewDefaultRoleCapability() *DefaultRoleCapability {
 // --------------------------------------------
 // Capabiltiy Type: Default Role Functions
 // --------------------------------------------
-func (f *DefaultRoleCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *DefaultRoleCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCoreDefaultRoleModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *DefaultRoleCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *DefaultRoleCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCoreDefaultRoleModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *DefaultRoleCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/firewall.go
+++ b/internal/provider/capability/capability_type/firewall.go
@@ -52,21 +52,21 @@ func NewFirewallAuditQuarantineCapability() *FirewallAuditQuarantineCapability {
 // --------------------------------------------
 // Capabiltiy Type: Firewall Audit & Quarantine Functions
 // --------------------------------------------
-func (f *FirewallAuditQuarantineCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *FirewallAuditQuarantineCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityFirewallAuditQuarantineModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *FirewallAuditQuarantineCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *FirewallAuditQuarantineCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityFirewallAuditQuarantineModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *FirewallAuditQuarantineCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/healthcheck.go
+++ b/internal/provider/capability/capability_type/healthcheck.go
@@ -51,21 +51,21 @@ func NewHealthcheckCapability() *HealthcheckCapability {
 // --------------------------------------------
 // Capabiltiy Type: Healthcheck Functions
 // --------------------------------------------
-func (f *HealthcheckCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *HealthcheckCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityHealthcheckModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *HealthcheckCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *HealthcheckCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityHealthcheckModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *HealthcheckCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/outreach.go
+++ b/internal/provider/capability/capability_type/outreach.go
@@ -52,21 +52,21 @@ func NewOutreachCapability() *OutreachCapability {
 // --------------------------------------------
 // Capabiltiy Type: Outreach Functions
 // --------------------------------------------
-func (f *OutreachCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *OutreachCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCoreOutreachModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *OutreachCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *OutreachCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCoreOutreachModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *OutreachCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/rut_auth.go
+++ b/internal/provider/capability/capability_type/rut_auth.go
@@ -51,21 +51,21 @@ func NewRutAuthCapability() *RutAuthCapability {
 // --------------------------------------------
 // Capabiltiy Type: RUT Auth Functions
 // --------------------------------------------
-func (f *RutAuthCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *RutAuthCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityRutAuthModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *RutAuthCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *RutAuthCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityRutAuthModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *RutAuthCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/storage_settings.go
+++ b/internal/provider/capability/capability_type/storage_settings.go
@@ -51,21 +51,21 @@ func NewCoreStorageSettingsCapability() *StorageSettingsCapability {
 // --------------------------------------------
 // Capabiltiy Type: Storage Settings Functions
 // --------------------------------------------
-func (f *StorageSettingsCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *StorageSettingsCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCoreStorageSettingsModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *StorageSettingsCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *StorageSettingsCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.CapabilityCoreStorageSettingsModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *StorageSettingsCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/ui_branding.go
+++ b/internal/provider/capability/capability_type/ui_branding.go
@@ -51,21 +51,21 @@ func NewUiBrandingCapability() *UiBrandingCapability {
 // --------------------------------------------
 // Capabiltiy Type: UI: Branding Functions
 // --------------------------------------------
-func (f *UiBrandingCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *UiBrandingCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.UiBrandingCapabilityModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *UiBrandingCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *UiBrandingCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.UiBrandingCapabilityModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *UiBrandingCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/ui_setting.go
+++ b/internal/provider/capability/capability_type/ui_setting.go
@@ -51,21 +51,21 @@ func NewUiSettingsCapability() *UiSettingsCapability {
 // --------------------------------------------
 // Capabiltiy Type: UI: Branding Functions
 // --------------------------------------------
-func (f *UiSettingsCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *UiSettingsCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.UiSettingsCapabilityModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *UiSettingsCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *UiSettingsCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.UiSettingsCapabilityModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *UiSettingsCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/webhook_global.go
+++ b/internal/provider/capability/capability_type/webhook_global.go
@@ -49,21 +49,21 @@ func NewWebhookGlobalCapability() *WebhookGlobalCapability {
 // --------------------------------------------
 // Capabiltiy Type: Webhook: Repository
 // --------------------------------------------
-func (f *WebhookGlobalCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *WebhookGlobalCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.WebhookGlobalCapabilityModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *WebhookGlobalCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *WebhookGlobalCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.WebhookGlobalCapabilityModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *WebhookGlobalCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_type/webhook_repository.go
+++ b/internal/provider/capability/capability_type/webhook_repository.go
@@ -49,21 +49,21 @@ func NewWebhookRepositoryCapability() *WebhookRepositoryCapability {
 // --------------------------------------------
 // Capabiltiy Type: Webhook: Repository
 // --------------------------------------------
-func (f *WebhookRepositoryCapability) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
+func (f *WebhookRepositoryCapability) DoCreateRequest(plan any, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*v3.CapabilityDTO, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.WebhookRepositoryCapabilityModel)
 
 	// Call API to Create
-	return apiClient.CapabilitiesAPI.Create4(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return svc.Create(ctx, *planModel.ToApiCreateModel(version))
 }
 
-func (f *WebhookRepositoryCapability) DoUpdateRequest(plan any, capabilityId string, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *WebhookRepositoryCapability) DoUpdateRequest(plan any, capabilityId string, svc common.CapabilityService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.WebhookRepositoryCapabilityModel)
 	planModel.Id = types.StringValue(capabilityId)
 
 	// Call API to Update
-	return apiClient.CapabilitiesAPI.Update3(ctx, capabilityId).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return svc.Update(ctx, capabilityId, *planModel.ToApiUpdateModel(version))
 }
 
 func (f *WebhookRepositoryCapability) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {

--- a/internal/provider/capability/capability_x_resource_test.go
+++ b/internal/provider/capability/capability_x_resource_test.go
@@ -36,6 +36,7 @@ const (
 	superSecretKeyFString = "super-secret-key-%s"
 	testingFString        = "TESTING 1 2 3 %s"
 	urlFString            = "https://%s.tld"
+	webhookUrlFString     = "https://example.com/%s"
 )
 
 func TestAccCapabilityAuditResource(t *testing.T) {
@@ -819,7 +820,7 @@ resource "%s" "cap" {
     names = [
       "repository"
     ]
-    url    = "https://%s.tld"
+    url    = "https://example.com/%s"
     secret = "super-secret-key-%s"
   }
 }
@@ -829,7 +830,7 @@ resource "%s" "cap" {
 					resource.TestCheckResourceAttr(resourceName, resourceAttrNotes, fmt.Sprintf(notesFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, resourceAttrEnabled, "true"),
 					resource.TestCheckTypeSetElemAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrNames), "repository"),
-					resource.TestCheckResourceAttr(resourceName, propertiesUrl, fmt.Sprintf(urlFString, randomString)),
+					resource.TestCheckResourceAttr(resourceName, propertiesUrl, fmt.Sprintf(webhookUrlFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrSecret), fmt.Sprintf(superSecretKeyFString, randomString)),
 				),
 			},
@@ -843,7 +844,7 @@ resource "%s" "cap" {
     names = [
       "repository"
     ]
-    url    = "https://%s.tld"
+    url    = "https://example.com/%s"
     secret = "super-secret-key-%s"
   }
 }
@@ -853,7 +854,7 @@ resource "%s" "cap" {
 					resource.TestCheckResourceAttr(resourceName, resourceAttrNotes, fmt.Sprintf(notesUpdatedFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, resourceAttrEnabled, "true"),
 					resource.TestCheckTypeSetElemAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrNames), "repository"),
-					resource.TestCheckResourceAttr(resourceName, propertiesUrl, fmt.Sprintf(urlFString, randomString)),
+					resource.TestCheckResourceAttr(resourceName, propertiesUrl, fmt.Sprintf(webhookUrlFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrSecret), fmt.Sprintf(superSecretKeyFString, randomString)),
 				),
 			},
@@ -891,7 +892,7 @@ resource "%s" "cap" {
     names = [
       "asset"
     ]
-    url    = "https://%s.tld"
+    url    = "https://example.com/%s"
     secret = "super-secret-key-%s"
 	repository = "maven-central"
   }
@@ -902,7 +903,7 @@ resource "%s" "cap" {
 					resource.TestCheckResourceAttr(resourceName, resourceAttrNotes, fmt.Sprintf(notesFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, resourceAttrEnabled, "true"),
 					resource.TestCheckTypeSetElemAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrNames), "asset"),
-					resource.TestCheckResourceAttr(resourceName, propertiesUrl, fmt.Sprintf(urlFString, randomString)),
+					resource.TestCheckResourceAttr(resourceName, propertiesUrl, fmt.Sprintf(webhookUrlFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrSecret), fmt.Sprintf(superSecretKeyFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrRepository), "maven-central"),
 				),
@@ -917,7 +918,7 @@ resource "%s" "cap" {
     names = [
       "asset"
     ]
-    url    = "https://%s.tld"
+    url    = "https://example.com/%s"
     secret = "super-secret-key-%s"
 	repository = "maven-central"
   }
@@ -928,7 +929,7 @@ resource "%s" "cap" {
 					resource.TestCheckResourceAttr(resourceName, resourceAttrNotes, fmt.Sprintf(notesUpdatedFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, resourceAttrEnabled, "true"),
 					resource.TestCheckTypeSetElemAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrNames), "asset"),
-					resource.TestCheckResourceAttr(resourceName, propertiesUrl, fmt.Sprintf(urlFString, randomString)),
+					resource.TestCheckResourceAttr(resourceName, propertiesUrl, fmt.Sprintf(webhookUrlFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrSecret), fmt.Sprintf(superSecretKeyFString, randomString)),
 					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf(resourceAttrPropertiesFormat, resourceAttrRepository), "maven-central"),
 				),

--- a/internal/provider/capability/capability_x_resource_test.go
+++ b/internal/provider/capability/capability_x_resource_test.go
@@ -368,6 +368,17 @@ func TestAccCapabilityFirewallAuditQuarantineResource(t *testing.T) {
 				Minor: 83,
 				Patch: 99,
 			})
+			// Broken from NXRM 3.94.0 onwards - server returns a 500 when updating
+			// firewall configuration for a repository
+			testutil.SkipIfNxrmVersionInRange(t, &common.SystemVersion{
+				Major: 3,
+				Minor: 94,
+				Patch: 0,
+			}, &common.SystemVersion{
+				Major: 127,
+				Minor: 127,
+				Patch: 127,
+			})
 		},
 		Steps: []resource.TestStep{
 			// Create and Read testing

--- a/internal/provider/common/anonymous_access_service.go
+++ b/internal/provider/common/anonymous_access_service.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// AnonymousAccessService abstracts anonymous access settings API across NXRM API client generations.
+type AnonymousAccessService interface {
+	GetAnonymousAccessSettings(ctx context.Context) (*sonatyperepoV382.AnonymousAccessSettingsXO, *http.Response, error)
+	UpdateAnonymousAccessSettings(ctx context.Context, body sonatyperepoV382.AnonymousAccessSettingsXO) (*sonatyperepoV382.AnonymousAccessSettingsXO, *http.Response, error)
+}
+
+// anonymousAccessServiceV382 implements AnonymousAccessService against NXRM API client V382 (targets NXRM < 3.94.0).
+type anonymousAccessServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func NewAnonymousAccessServiceV382(client *sonatyperepoV382.APIClient) AnonymousAccessService {
+	return &anonymousAccessServiceV382{client: client}
+}
+
+func (s *anonymousAccessServiceV382) GetAnonymousAccessSettings(ctx context.Context) (*sonatyperepoV382.AnonymousAccessSettingsXO, *http.Response, error) {
+	return s.client.SecurityManagementAnonymousAccessAPI.Read1(ctx).Execute()
+}
+
+func (s *anonymousAccessServiceV382) UpdateAnonymousAccessSettings(ctx context.Context, body sonatyperepoV382.AnonymousAccessSettingsXO) (*sonatyperepoV382.AnonymousAccessSettingsXO, *http.Response, error) {
+	return s.client.SecurityManagementAnonymousAccessAPI.Update1(ctx).Body(body).Execute()
+}
+
+// anonymousAccessServiceV395 implements AnonymousAccessService against NXRM API client V395 (targets NXRM 3.94.0+).
+type anonymousAccessServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func NewAnonymousAccessServiceV395(client *sonatyperepoV395.APIClient) AnonymousAccessService {
+	return &anonymousAccessServiceV395{client: client}
+}
+
+func (s *anonymousAccessServiceV395) GetAnonymousAccessSettings(ctx context.Context) (*sonatyperepoV382.AnonymousAccessSettingsXO, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.SecurityManagementAnonymousAccessAPI.ListSecurityAnonymous(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AnonymousAccessSettingsXO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *anonymousAccessServiceV395) UpdateAnonymousAccessSettings(ctx context.Context, body sonatyperepoV382.AnonymousAccessSettingsXO) (*sonatyperepoV382.AnonymousAccessSettingsXO, *http.Response, error) {
+	var v395Body sonatyperepoV395.AnonymousAccessSettingsXO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, nil, err
+	}
+	apiV395, httpResponse, err := s.client.SecurityManagementAnonymousAccessAPI.UpdateSecurityAnonymous(ctx).AnonymousAccessSettingsXO(v395Body).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AnonymousAccessSettingsXO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}

--- a/internal/provider/common/blob_store_service.go
+++ b/internal/provider/common/blob_store_service.go
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// BlobStoreService abstracts blob store CRUD across NXRM API client generations.
+// Every method's request/response shape is expressed in terms of the V382 generated types.
+type BlobStoreService interface {
+	// S3 Blob Store operations
+	CreateS3BlobStore(ctx context.Context, body sonatyperepoV382.S3BlobStoreApiModel) (*http.Response, error)
+	GetS3BlobStore(ctx context.Context, name string) (*sonatyperepoV382.S3BlobStoreApiModel, *http.Response, error)
+	UpdateS3BlobStore(ctx context.Context, name string, body sonatyperepoV382.S3BlobStoreApiModel) (*http.Response, error)
+
+	// File Blob Store operations
+	CreateFileBlobStore(ctx context.Context, body sonatyperepoV382.FileBlobStoreApiCreateRequest) (*http.Response, error)
+	GetFileBlobStoreConfiguration(ctx context.Context, name string) (*sonatyperepoV382.FileBlobStoreApiModel, *http.Response, error)
+	UpdateFileBlobStore(ctx context.Context, name string, body sonatyperepoV382.FileBlobStoreApiUpdateRequest) (*http.Response, error)
+
+	// Group Blob Store operations
+	CreateGroupBlobStore(ctx context.Context, body sonatyperepoV382.GroupBlobStoreApiCreateRequest) (*http.Response, error)
+	GetGroupBlobStoreConfiguration(ctx context.Context, name string) (*sonatyperepoV382.GroupBlobStoreApiModel, *http.Response, error)
+	UpdateGroupBlobStore(ctx context.Context, name string, body sonatyperepoV382.GroupBlobStoreApiUpdateRequest) (*http.Response, error)
+
+	// Azure Cloud Storage (ACS) Blob Store operations (named CreateBlobStore1/GetBlobStore1/UpdateBlobStore1 in V382)
+	CreateBlobStore1(ctx context.Context, body sonatyperepoV382.AzureBlobStoreApiModel) (*http.Response, error)
+	GetBlobStore1(ctx context.Context, name string) (*sonatyperepoV382.AzureBlobStoreApiModel, *http.Response, error)
+	UpdateBlobStore1(ctx context.Context, name string, body sonatyperepoV382.AzureBlobStoreApiModel) (*http.Response, error)
+
+	// Google Cloud Blob Store operations (named CreateBlobStore2/GetBlobStore2/UpdateBlobStore2 in V382)
+	CreateBlobStore2(ctx context.Context, body sonatyperepoV382.GoogleCloudBlobstoreApiModel) (*http.Response, error)
+	GetBlobStore2(ctx context.Context, name string) (*sonatyperepoV382.GoogleCloudBlobstoreApiModel, *http.Response, error)
+	UpdateBlobStore2(ctx context.Context, name string, body sonatyperepoV382.GoogleCloudBlobstoreApiModel) (*http.Response, error)
+
+	// List all blob stores
+	ListBlobStores(ctx context.Context) ([]sonatyperepoV382.GenericBlobStoreApiResponse, *http.Response, error)
+}
+
+// blobStoreServiceV382 implements BlobStoreService against NXRM API client V382 (targets NXRM < 3.94.0).
+type blobStoreServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+// blobStoreServiceV395 implements BlobStoreService against NXRM API client V395 (targets NXRM 3.94.0+).
+type blobStoreServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+// ============================================================================
+// V382 Implementation - Pure passthrough
+// ============================================================================
+
+func (s *blobStoreServiceV382) CreateS3BlobStore(ctx context.Context, body sonatyperepoV382.S3BlobStoreApiModel) (*http.Response, error) {
+	return s.client.BlobStoreAPI.CreateS3BlobStore(ctx).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) GetS3BlobStore(ctx context.Context, name string) (*sonatyperepoV382.S3BlobStoreApiModel, *http.Response, error) {
+	return s.client.BlobStoreAPI.GetS3BlobStore(ctx, name).Execute()
+}
+
+func (s *blobStoreServiceV382) UpdateS3BlobStore(ctx context.Context, name string, body sonatyperepoV382.S3BlobStoreApiModel) (*http.Response, error) {
+	return s.client.BlobStoreAPI.UpdateS3BlobStore(ctx, name).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) CreateFileBlobStore(ctx context.Context, body sonatyperepoV382.FileBlobStoreApiCreateRequest) (*http.Response, error) {
+	return s.client.BlobStoreAPI.CreateFileBlobStore(ctx).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) GetFileBlobStoreConfiguration(ctx context.Context, name string) (*sonatyperepoV382.FileBlobStoreApiModel, *http.Response, error) {
+	return s.client.BlobStoreAPI.GetFileBlobStoreConfiguration(ctx, name).Execute()
+}
+
+func (s *blobStoreServiceV382) UpdateFileBlobStore(ctx context.Context, name string, body sonatyperepoV382.FileBlobStoreApiUpdateRequest) (*http.Response, error) {
+	return s.client.BlobStoreAPI.UpdateFileBlobStore(ctx, name).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) CreateGroupBlobStore(ctx context.Context, body sonatyperepoV382.GroupBlobStoreApiCreateRequest) (*http.Response, error) {
+	return s.client.BlobStoreAPI.CreateGroupBlobStore(ctx).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) GetGroupBlobStoreConfiguration(ctx context.Context, name string) (*sonatyperepoV382.GroupBlobStoreApiModel, *http.Response, error) {
+	return s.client.BlobStoreAPI.GetGroupBlobStoreConfiguration(ctx, name).Execute()
+}
+
+func (s *blobStoreServiceV382) UpdateGroupBlobStore(ctx context.Context, name string, body sonatyperepoV382.GroupBlobStoreApiUpdateRequest) (*http.Response, error) {
+	return s.client.BlobStoreAPI.UpdateGroupBlobStore(ctx, name).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) CreateBlobStore1(ctx context.Context, body sonatyperepoV382.AzureBlobStoreApiModel) (*http.Response, error) {
+	return s.client.BlobStoreAPI.CreateBlobStore1(ctx).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) GetBlobStore1(ctx context.Context, name string) (*sonatyperepoV382.AzureBlobStoreApiModel, *http.Response, error) {
+	return s.client.BlobStoreAPI.GetBlobStore1(ctx, name).Execute()
+}
+
+func (s *blobStoreServiceV382) UpdateBlobStore1(ctx context.Context, name string, body sonatyperepoV382.AzureBlobStoreApiModel) (*http.Response, error) {
+	return s.client.BlobStoreAPI.UpdateBlobStore1(ctx, name).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) CreateBlobStore2(ctx context.Context, body sonatyperepoV382.GoogleCloudBlobstoreApiModel) (*http.Response, error) {
+	return s.client.BlobStoreAPI.CreateBlobStore2(ctx).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) GetBlobStore2(ctx context.Context, name string) (*sonatyperepoV382.GoogleCloudBlobstoreApiModel, *http.Response, error) {
+	return s.client.BlobStoreAPI.GetBlobStore2(ctx, name).Execute()
+}
+
+func (s *blobStoreServiceV382) UpdateBlobStore2(ctx context.Context, name string, body sonatyperepoV382.GoogleCloudBlobstoreApiModel) (*http.Response, error) {
+	return s.client.BlobStoreAPI.UpdateBlobStore2(ctx, name).Body(body).Execute()
+}
+
+func (s *blobStoreServiceV382) ListBlobStores(ctx context.Context) ([]sonatyperepoV382.GenericBlobStoreApiResponse, *http.Response, error) {
+	return s.client.BlobStoreAPI.ListBlobStores(ctx).Execute()
+}
+
+// ============================================================================
+// V395 Implementation - Bridges to V395 API via jsonBridge
+// ============================================================================
+
+func (s *blobStoreServiceV395) CreateS3BlobStore(ctx context.Context, body sonatyperepoV382.S3BlobStoreApiModel) (*http.Response, error) {
+	var v395Body sonatyperepoV395.S3BlobStoreApiModel
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.CreateS3BlobStore(ctx).S3BlobStoreApiModel(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) GetS3BlobStore(ctx context.Context, name string) (*sonatyperepoV382.S3BlobStoreApiModel, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.BlobStoreAPI.GetS3BlobStore(ctx, name).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.S3BlobStoreApiModel
+	if err := jsonBridge(v395Response, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *blobStoreServiceV395) UpdateS3BlobStore(ctx context.Context, name string, body sonatyperepoV382.S3BlobStoreApiModel) (*http.Response, error) {
+	var v395Body sonatyperepoV395.S3BlobStoreApiModel
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.UpdateS3BlobStore(ctx, name).S3BlobStoreApiModel(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) CreateFileBlobStore(ctx context.Context, body sonatyperepoV382.FileBlobStoreApiCreateRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.FileBlobStoreApiCreateRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.CreateBlobstoresFile(ctx).FileBlobStoreApiCreateRequest(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) GetFileBlobStoreConfiguration(ctx context.Context, name string) (*sonatyperepoV382.FileBlobStoreApiModel, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.BlobStoreAPI.GetBlobstoresFile(ctx, name).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.FileBlobStoreApiModel
+	if err := jsonBridge(v395Response, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *blobStoreServiceV395) UpdateFileBlobStore(ctx context.Context, name string, body sonatyperepoV382.FileBlobStoreApiUpdateRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.FileBlobStoreApiUpdateRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.UpdateBlobstoresFile(ctx, name).FileBlobStoreApiUpdateRequest(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) CreateGroupBlobStore(ctx context.Context, body sonatyperepoV382.GroupBlobStoreApiCreateRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GroupBlobStoreApiCreateRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.CreateBlobstoresGroup(ctx).GroupBlobStoreApiCreateRequest(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) GetGroupBlobStoreConfiguration(ctx context.Context, name string) (*sonatyperepoV382.GroupBlobStoreApiModel, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.BlobStoreAPI.GetBlobstoresGroup(ctx, name).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.GroupBlobStoreApiModel
+	if err := jsonBridge(v395Response, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *blobStoreServiceV395) UpdateGroupBlobStore(ctx context.Context, name string, body sonatyperepoV382.GroupBlobStoreApiUpdateRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GroupBlobStoreApiUpdateRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.UpdateBlobstoresGroup(ctx, name).GroupBlobStoreApiUpdateRequest(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) CreateBlobStore1(ctx context.Context, body sonatyperepoV382.AzureBlobStoreApiModel) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AzureBlobStoreApiModel
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.CreateBlobstoresAzure(ctx).AzureBlobStoreApiModel(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) GetBlobStore1(ctx context.Context, name string) (*sonatyperepoV382.AzureBlobStoreApiModel, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.BlobStoreAPI.GetBlobstoresAzure(ctx, name).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AzureBlobStoreApiModel
+	if err := jsonBridge(v395Response, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *blobStoreServiceV395) UpdateBlobStore1(ctx context.Context, name string, body sonatyperepoV382.AzureBlobStoreApiModel) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AzureBlobStoreApiModel
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.UpdateBlobstoresAzure(ctx, name).AzureBlobStoreApiModel(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) CreateBlobStore2(ctx context.Context, body sonatyperepoV382.GoogleCloudBlobstoreApiModel) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GoogleCloudBlobstoreApiModel
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.CreateBlobstoresGoogle(ctx).GoogleCloudBlobstoreApiModel(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) GetBlobStore2(ctx context.Context, name string) (*sonatyperepoV382.GoogleCloudBlobstoreApiModel, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.BlobStoreAPI.GetBlobstoresGoogle(ctx, name).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.GoogleCloudBlobstoreApiModel
+	if err := jsonBridge(v395Response, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *blobStoreServiceV395) UpdateBlobStore2(ctx context.Context, name string, body sonatyperepoV382.GoogleCloudBlobstoreApiModel) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GoogleCloudBlobstoreApiModel
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.BlobStoreAPI.UpdateBlobstoresGoogle(ctx, name).GoogleCloudBlobstoreApiModel(v395Body).Execute()
+}
+
+func (s *blobStoreServiceV395) ListBlobStores(ctx context.Context) ([]sonatyperepoV382.GenericBlobStoreApiResponse, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.BlobStoreAPI.ListBlobstores(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result []sonatyperepoV382.GenericBlobStoreApiResponse
+	if err := jsonBridge(v395Response, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return result, httpResponse, nil
+}

--- a/internal/provider/common/capability_service.go
+++ b/internal/provider/common/capability_service.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// CapabilityService abstracts the Capabilities API across NXRM API client generations.
+type CapabilityService interface {
+	// Create creates a new capability.
+	Create(ctx context.Context, body sonatyperepoV382.CapabilityDTO) (*sonatyperepoV382.CapabilityDTO, *http.Response, error)
+	// Update updates an existing capability by ID.
+	Update(ctx context.Context, capabilityId string, body sonatyperepoV382.CapabilityDTO) (*http.Response, error)
+	// Delete deletes a capability by ID.
+	Delete(ctx context.Context, capabilityId string) (*http.Response, error)
+	// List lists all capabilities.
+	List(ctx context.Context) ([]sonatyperepoV382.CapabilityDTO, *http.Response, error)
+}
+
+// capabilityServiceV382 implements CapabilityService against NXRM API client V382 (targets NXRM < 3.94.0).
+type capabilityServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *capabilityServiceV382) Create(ctx context.Context, body sonatyperepoV382.CapabilityDTO) (*sonatyperepoV382.CapabilityDTO, *http.Response, error) {
+	return s.client.CapabilitiesAPI.Create4(ctx).Body(body).Execute()
+}
+
+func (s *capabilityServiceV382) Update(ctx context.Context, capabilityId string, body sonatyperepoV382.CapabilityDTO) (*http.Response, error) {
+	return s.client.CapabilitiesAPI.Update3(ctx, capabilityId).Body(body).Execute()
+}
+
+func (s *capabilityServiceV382) Delete(ctx context.Context, capabilityId string) (*http.Response, error) {
+	return s.client.CapabilitiesAPI.Delete5(ctx, capabilityId).Execute()
+}
+
+func (s *capabilityServiceV382) List(ctx context.Context) ([]sonatyperepoV382.CapabilityDTO, *http.Response, error) {
+	return s.client.CapabilitiesAPI.List2(ctx).Execute()
+}
+
+// capabilityServiceV395 implements CapabilityService against NXRM API client V395 (targets NXRM 3.94.0+).
+type capabilityServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *capabilityServiceV395) Create(ctx context.Context, body sonatyperepoV382.CapabilityDTO) (*sonatyperepoV382.CapabilityDTO, *http.Response, error) {
+	// Bridge the V382-shaped request into V395 shape
+	var v395Body sonatyperepoV395.CapabilityDTO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, nil, err
+	}
+
+	apiV395, httpResponse, err := s.client.CapabilitiesAPI.CreateCapabilities(ctx).CapabilityDTO(v395Body).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.CapabilityDTO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *capabilityServiceV395) Update(ctx context.Context, capabilityId string, body sonatyperepoV382.CapabilityDTO) (*http.Response, error) {
+	// Bridge the V382-shaped request into V395 shape
+	var v395Body sonatyperepoV395.CapabilityDTO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+
+	return s.client.CapabilitiesAPI.UpdateCapabilities(ctx, capabilityId).CapabilityDTO(v395Body).Execute()
+}
+
+func (s *capabilityServiceV395) Delete(ctx context.Context, capabilityId string) (*http.Response, error) {
+	return s.client.CapabilitiesAPI.DeleteCapabilities(ctx, capabilityId).Execute()
+}
+
+func (s *capabilityServiceV395) List(ctx context.Context) ([]sonatyperepoV382.CapabilityDTO, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.CapabilitiesAPI.ListCapabilities(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result []sonatyperepoV382.CapabilityDTO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return result, httpResponse, nil
+}

--- a/internal/provider/common/certificates_service.go
+++ b/internal/provider/common/certificates_service.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// CertificatesService abstracts the Security Certificates API across NXRM API client generations.
+type CertificatesService interface {
+	// AddCertificate adds a certificate to the truststore.
+	AddCertificate(ctx context.Context, pemBody string) (*sonatyperepoV382.ApiCertificate, *http.Response, error)
+	// GetTrustStoreCertificates retrieves all certificates from the truststore.
+	GetTrustStoreCertificates(ctx context.Context) ([]sonatyperepoV382.ApiCertificate, *http.Response, error)
+	// RemoveCertificate removes a certificate from the truststore by ID.
+	RemoveCertificate(ctx context.Context, id string) (*http.Response, error)
+}
+
+// certificatesServiceV382 implements CertificatesService against NXRM API client V382 (targets NXRM < 3.94.0).
+type certificatesServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *certificatesServiceV382) AddCertificate(ctx context.Context, pemBody string) (*sonatyperepoV382.ApiCertificate, *http.Response, error) {
+	return s.client.SecurityCertificatesAPI.AddCertificate(ctx).Body(pemBody).Execute()
+}
+
+func (s *certificatesServiceV382) GetTrustStoreCertificates(ctx context.Context) ([]sonatyperepoV382.ApiCertificate, *http.Response, error) {
+	return s.client.SecurityCertificatesAPI.GetTrustStoreCertificates(ctx).Execute()
+}
+
+func (s *certificatesServiceV382) RemoveCertificate(ctx context.Context, id string) (*http.Response, error) {
+	return s.client.SecurityCertificatesAPI.RemoveCertificate(ctx, id).Execute()
+}
+
+// certificatesServiceV395 implements CertificatesService against NXRM API client V395 (targets NXRM 3.94.0+).
+type certificatesServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *certificatesServiceV395) AddCertificate(ctx context.Context, pemBody string) (*sonatyperepoV382.ApiCertificate, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.SecurityCertificatesAPI.CreateSecuritySslTruststore(ctx).Body(pemBody).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 response to V382 shape
+	var v382Response sonatyperepoV382.ApiCertificate
+	if err := jsonBridge(v395Response, &v382Response); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &v382Response, httpResponse, nil
+}
+
+func (s *certificatesServiceV395) GetTrustStoreCertificates(ctx context.Context) ([]sonatyperepoV382.ApiCertificate, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.SecurityCertificatesAPI.ListSecuritySslTruststore(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 response to V382 shape
+	v382Response := make([]sonatyperepoV382.ApiCertificate, len(v395Response))
+	for i, v395Cert := range v395Response {
+		if err := jsonBridge(v395Cert, &v382Response[i]); err != nil {
+			return nil, httpResponse, err
+		}
+	}
+
+	return v382Response, httpResponse, nil
+}
+
+func (s *certificatesServiceV395) RemoveCertificate(ctx context.Context, id string) (*http.Response, error) {
+	return s.client.SecurityCertificatesAPI.DeleteSecuritySslTruststore(ctx, id).Execute()
+}
+
+// NewCertificatesServiceV382 creates a V382 CertificatesService adapter.
+func NewCertificatesServiceV382(client *sonatyperepoV382.APIClient) CertificatesService {
+	return &certificatesServiceV382{client: client}
+}
+
+// NewCertificatesServiceV395 creates a V395 CertificatesService adapter.
+func NewCertificatesServiceV395(client *sonatyperepoV395.APIClient) CertificatesService {
+	return &certificatesServiceV395{client: client}
+}

--- a/internal/provider/common/cleanup_policy_service.go
+++ b/internal/provider/common/cleanup_policy_service.go
@@ -99,7 +99,7 @@ func (s *cleanupPolicyServiceV395) GetByName(ctx context.Context, name string) (
 	// response has an extra 'repositories' field V382's struct doesn't know about, so prune the
 	// raw body down to V382's shape here before the caller ever sees it.
 	body, readErr := io.ReadAll(httpResponse.Body)
-	httpResponse.Body.Close()
+	_ = httpResponse.Body.Close()
 	if readErr != nil {
 		return httpResponse, fmt.Errorf("could not read response body: %w", readErr)
 	}

--- a/internal/provider/common/cleanup_policy_service.go
+++ b/internal/provider/common/cleanup_policy_service.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// CleanupPolicyService abstracts cleanup policy CRUD across NXRM API client generations.
+// Every method's request/response shape is expressed in terms of the V382 generated types --
+// the vocabulary the existing internal/provider/model package's methods are already written against.
+// The V395 adapter bridges to/from its own generated types internally so that callers never need
+// to know which generation is behind the interface.
+type CleanupPolicyService interface {
+	// Create creates a new cleanup policy.
+	Create(ctx context.Context, body sonatyperepoV382.CleanupPolicyResourceXO) (*http.Response, error)
+	// GetByName retrieves a cleanup policy by name.
+	GetByName(ctx context.Context, name string) (*http.Response, error)
+	// Update updates an existing cleanup policy.
+	Update(ctx context.Context, policyName string, body sonatyperepoV382.CleanupPolicyResourceXO) (*http.Response, error)
+	// DeleteByName deletes a cleanup policy by name.
+	DeleteByName(ctx context.Context, name string) (*http.Response, error)
+}
+
+// cleanupPolicyServiceV382 implements CleanupPolicyService against NXRM API client V382 (targets NXRM < 3.94.0).
+type cleanupPolicyServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func NewCleanupPolicyServiceV382(client *sonatyperepoV382.APIClient) CleanupPolicyService {
+	return &cleanupPolicyServiceV382{client: client}
+}
+
+func (s *cleanupPolicyServiceV382) Create(ctx context.Context, body sonatyperepoV382.CleanupPolicyResourceXO) (*http.Response, error) {
+	return s.client.CleanupPoliciesAPI.Create1(ctx).Body(body).Execute()
+}
+
+func (s *cleanupPolicyServiceV382) GetByName(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.CleanupPoliciesAPI.GetCleanupPolicyByName(ctx, name).Execute()
+}
+
+func (s *cleanupPolicyServiceV382) Update(ctx context.Context, policyName string, body sonatyperepoV382.CleanupPolicyResourceXO) (*http.Response, error) {
+	return s.client.CleanupPoliciesAPI.Update2(ctx, policyName).Body(body).Execute()
+}
+
+func (s *cleanupPolicyServiceV382) DeleteByName(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.CleanupPoliciesAPI.DeletePolicyByName(ctx, name).Execute()
+}
+
+// cleanupPolicyServiceV395 implements CleanupPolicyService against NXRM API client V395 (targets NXRM 3.94.0+).
+type cleanupPolicyServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func NewCleanupPolicyServiceV395(client *sonatyperepoV395.APIClient) CleanupPolicyService {
+	return &cleanupPolicyServiceV395{client: client}
+}
+
+func (s *cleanupPolicyServiceV395) Create(ctx context.Context, body sonatyperepoV382.CleanupPolicyResourceXO) (*http.Response, error) {
+	// Bridge the V382-shaped request into V395 shape
+	var v395Body sonatyperepoV395.CleanupPolicyResourceXO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+
+	return s.client.CleanupPoliciesAPI.CreateCleanupPolicies(ctx).CleanupPolicyResourceXO(v395Body).Execute()
+}
+
+func (s *cleanupPolicyServiceV395) GetByName(ctx context.Context, name string) (*http.Response, error) {
+	httpResponse, err := s.client.CleanupPoliciesAPI.GetCleanupPolicies(ctx, name).Execute()
+	if err != nil {
+		return httpResponse, err
+	}
+
+	// The API doesn't declare a typed response for this endpoint in either client generation,
+	// so callers manually decode the body into the V382 CleanupPolicyResourceXO shape. V395's
+	// response has an extra 'repositories' field V382's struct doesn't know about, so prune the
+	// raw body down to V382's shape here before the caller ever sees it.
+	body, readErr := io.ReadAll(httpResponse.Body)
+	httpResponse.Body.Close()
+	if readErr != nil {
+		return httpResponse, fmt.Errorf("could not read response body: %w", readErr)
+	}
+
+	pruned, pruneErr := pruneUnknownJSONFields(body, reflect.TypeOf(sonatyperepoV382.CleanupPolicyResourceXO{}))
+	if pruneErr != nil {
+		httpResponse.Body = io.NopCloser(bytes.NewReader(body))
+		return httpResponse, pruneErr
+	}
+
+	httpResponse.Body = io.NopCloser(bytes.NewReader(pruned))
+	return httpResponse, nil
+}
+
+func (s *cleanupPolicyServiceV395) Update(ctx context.Context, policyName string, body sonatyperepoV382.CleanupPolicyResourceXO) (*http.Response, error) {
+	// Bridge the V382-shaped request into V395 shape
+	var v395Body sonatyperepoV395.CleanupPolicyResourceXO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+
+	return s.client.CleanupPoliciesAPI.UpdateCleanupPolicies(ctx, policyName).CleanupPolicyResourceXO(v395Body).Execute()
+}
+
+func (s *cleanupPolicyServiceV395) DeleteByName(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.CleanupPoliciesAPI.DeleteCleanupPolicies(ctx, name).Execute()
+}

--- a/internal/provider/common/configuration_service.go
+++ b/internal/provider/common/configuration_service.go
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// ConfigurationService abstracts Email, LDAP, and IQ Connection configuration
+// APIs across NXRM API client generations. Every method's request/response shape
+// is expressed in terms of the V382 generated types, matching the existing model
+// mapping layer's expectations.
+type ConfigurationService interface {
+	// Email
+	SetEmailConfiguration(ctx context.Context, body sonatyperepoV382.ApiEmailConfiguration) (*http.Response, error)
+	GetEmailConfiguration(ctx context.Context) (*sonatyperepoV382.ApiEmailConfiguration, *http.Response, error)
+	DeleteEmailConfiguration(ctx context.Context) (*http.Response, error)
+
+	// LDAP
+	CreateLdapServer(ctx context.Context, body sonatyperepoV382.CreateLdapServerXo) (*http.Response, error)
+	GetLdapServer(ctx context.Context, name string) (*sonatyperepoV382.ReadLdapServerXo, *http.Response, error)
+	UpdateLdapServer(ctx context.Context, name string, body sonatyperepoV382.UpdateLdapServerXo) (*http.Response, error)
+	DeleteLdapServer(ctx context.Context, name string) (*http.Response, error)
+
+	// IQ Connection
+	GetIqConnectionConfiguration(ctx context.Context) (*sonatyperepoV382.IqConnectionXo, *http.Response, error)
+	UpdateIqConnectionConfiguration(ctx context.Context, body sonatyperepoV382.IqConnectionXo) (*sonatyperepoV382.IqConnectionXo, *http.Response, error)
+	DisableIq(ctx context.Context) (*http.Response, error)
+	VerifyIqConnection(ctx context.Context) (*sonatyperepoV382.IqConnectionVerificationXo, *http.Response, error)
+}
+
+// configurationServiceV382 implements ConfigurationService against NXRM API client V382
+// (targets NXRM < 3.94.0).
+type configurationServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+// configurationServiceV395 implements ConfigurationService against NXRM API client V395
+// (targets NXRM 3.94.0+). Requests/responses are bridged to/from V382 shapes via JSON,
+// since the internal/provider/model package's mapping methods are written in terms of
+// V382 types.
+type configurationServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+// Email API implementation - V382
+
+func (s *configurationServiceV382) SetEmailConfiguration(ctx context.Context, body sonatyperepoV382.ApiEmailConfiguration) (*http.Response, error) {
+	return s.client.EmailAPI.SetEmailConfiguration(ctx).Body(body).Execute()
+}
+
+func (s *configurationServiceV382) GetEmailConfiguration(ctx context.Context) (*sonatyperepoV382.ApiEmailConfiguration, *http.Response, error) {
+	return s.client.EmailAPI.GetEmailConfiguration(ctx).Execute()
+}
+
+func (s *configurationServiceV382) DeleteEmailConfiguration(ctx context.Context) (*http.Response, error) {
+	return s.client.EmailAPI.DeleteEmailConfiguration(ctx).Execute()
+}
+
+// Email API implementation - V395
+
+func (s *configurationServiceV395) SetEmailConfiguration(ctx context.Context, body sonatyperepoV382.ApiEmailConfiguration) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ApiEmailConfiguration
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.EmailAPI.UpdateEmail(ctx).ApiEmailConfiguration(v395Body).Execute()
+}
+
+func (s *configurationServiceV395) GetEmailConfiguration(ctx context.Context) (*sonatyperepoV382.ApiEmailConfiguration, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.EmailAPI.ListEmail(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.ApiEmailConfiguration
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *configurationServiceV395) DeleteEmailConfiguration(ctx context.Context) (*http.Response, error) {
+	return s.client.EmailAPI.DeleteEmail(ctx).Execute()
+}
+
+// LDAP API implementation - V382
+
+func (s *configurationServiceV382) CreateLdapServer(ctx context.Context, body sonatyperepoV382.CreateLdapServerXo) (*http.Response, error) {
+	return s.client.SecurityManagementLDAPAPI.CreateLdapServer(ctx).Body(body).Execute()
+}
+
+func (s *configurationServiceV382) GetLdapServer(ctx context.Context, name string) (*sonatyperepoV382.ReadLdapServerXo, *http.Response, error) {
+	return s.client.SecurityManagementLDAPAPI.GetLdapServer(ctx, name).Execute()
+}
+
+func (s *configurationServiceV382) UpdateLdapServer(ctx context.Context, name string, body sonatyperepoV382.UpdateLdapServerXo) (*http.Response, error) {
+	return s.client.SecurityManagementLDAPAPI.UpdateLdapServer(ctx, name).Body(body).Execute()
+}
+
+func (s *configurationServiceV382) DeleteLdapServer(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.SecurityManagementLDAPAPI.DeleteLdapServer(ctx, name).Execute()
+}
+
+// LDAP API implementation - V395
+
+func (s *configurationServiceV395) CreateLdapServer(ctx context.Context, body sonatyperepoV382.CreateLdapServerXo) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CreateLdapServerXo
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.SecurityManagementLDAPAPI.CreateSecurityLdap(ctx).CreateLdapServerXo(v395Body).Execute()
+}
+
+func (s *configurationServiceV395) GetLdapServer(ctx context.Context, name string) (*sonatyperepoV382.ReadLdapServerXo, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.SecurityManagementLDAPAPI.GetSecurityLdap(ctx, name).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.ReadLdapServerXo
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *configurationServiceV395) UpdateLdapServer(ctx context.Context, name string, body sonatyperepoV382.UpdateLdapServerXo) (*http.Response, error) {
+	var v395Body sonatyperepoV395.UpdateLdapServerXo
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.SecurityManagementLDAPAPI.UpdateSecurityLdap(ctx, name).UpdateLdapServerXo(v395Body).Execute()
+}
+
+func (s *configurationServiceV395) DeleteLdapServer(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.SecurityManagementLDAPAPI.DeleteSecurityLdap(ctx, name).Execute()
+}
+
+// IQ Connection API implementation - V382
+
+func (s *configurationServiceV382) GetIqConnectionConfiguration(ctx context.Context) (*sonatyperepoV382.IqConnectionXo, *http.Response, error) {
+	return s.client.ManageSonatypeRepositoryFirewallConfigurationAPI.GetConfiguration1(ctx).Execute()
+}
+
+func (s *configurationServiceV382) UpdateIqConnectionConfiguration(ctx context.Context, body sonatyperepoV382.IqConnectionXo) (*sonatyperepoV382.IqConnectionXo, *http.Response, error) {
+	return s.client.ManageSonatypeRepositoryFirewallConfigurationAPI.UpdateConfiguration1(ctx).Body(body).Execute()
+}
+
+func (s *configurationServiceV382) DisableIq(ctx context.Context) (*http.Response, error) {
+	return s.client.ManageSonatypeRepositoryFirewallConfigurationAPI.DisableIq(ctx).Execute()
+}
+
+func (s *configurationServiceV382) VerifyIqConnection(ctx context.Context) (*sonatyperepoV382.IqConnectionVerificationXo, *http.Response, error) {
+	return s.client.ManageSonatypeRepositoryFirewallConfigurationAPI.VerifyIqConnection(ctx).Execute()
+}
+
+// IQ Connection API implementation - V395
+
+func (s *configurationServiceV395) GetIqConnectionConfiguration(ctx context.Context) (*sonatyperepoV382.IqConnectionXo, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.ManageSonatypeRepositoryFirewallConfigurationAPI.ListIq(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.IqConnectionXo
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *configurationServiceV395) UpdateIqConnectionConfiguration(ctx context.Context, body sonatyperepoV382.IqConnectionXo) (*sonatyperepoV382.IqConnectionXo, *http.Response, error) {
+	var v395Body sonatyperepoV395.IqConnectionXo
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, nil, err
+	}
+	apiV395, httpResponse, err := s.client.ManageSonatypeRepositoryFirewallConfigurationAPI.UpdateIq(ctx).IqConnectionXo(v395Body).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.IqConnectionXo
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *configurationServiceV395) DisableIq(ctx context.Context) (*http.Response, error) {
+	return s.client.ManageSonatypeRepositoryFirewallConfigurationAPI.CreateIqDisable(ctx).Execute()
+}
+
+func (s *configurationServiceV395) VerifyIqConnection(ctx context.Context) (*sonatyperepoV382.IqConnectionVerificationXo, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.ManageSonatypeRepositoryFirewallConfigurationAPI.VerifyIqConnection(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.IqConnectionVerificationXo
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}

--- a/internal/provider/common/content_selector_service.go
+++ b/internal/provider/common/content_selector_service.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// ContentSelectorService abstracts the Content Selectors API across NXRM API client generations.
+// Every method's request/response shape is expressed in terms of the V382 generated types --
+// the vocabulary the existing internal/provider/model package's mapping methods are already
+// written against.
+type ContentSelectorService interface {
+	CreateContentSelector(ctx context.Context, body sonatyperepoV382.ContentSelectorApiCreateRequest) (*http.Response, error)
+	GetContentSelector(ctx context.Context, name string) (*sonatyperepoV382.ContentSelectorApiResponse, *http.Response, error)
+	UpdateContentSelector(ctx context.Context, name string, body sonatyperepoV382.ContentSelectorApiUpdateRequest) (*http.Response, error)
+	DeleteContentSelector(ctx context.Context, name string) (*http.Response, error)
+	GetContentSelectors(ctx context.Context) ([]sonatyperepoV382.ContentSelectorApiResponse, *http.Response, error)
+}
+
+// contentSelectorServiceV382 implements ContentSelectorService against NXRM API client V382 (targets NXRM < 3.94.0).
+type contentSelectorServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *contentSelectorServiceV382) CreateContentSelector(ctx context.Context, body sonatyperepoV382.ContentSelectorApiCreateRequest) (*http.Response, error) {
+	return s.client.ContentSelectorsAPI.CreateContentSelector(ctx).Body(body).Execute()
+}
+
+func (s *contentSelectorServiceV382) GetContentSelector(ctx context.Context, name string) (*sonatyperepoV382.ContentSelectorApiResponse, *http.Response, error) {
+	return s.client.ContentSelectorsAPI.GetContentSelector(ctx, name).Execute()
+}
+
+func (s *contentSelectorServiceV382) UpdateContentSelector(ctx context.Context, name string, body sonatyperepoV382.ContentSelectorApiUpdateRequest) (*http.Response, error) {
+	return s.client.ContentSelectorsAPI.UpdateContentSelector(ctx, name).Body(body).Execute()
+}
+
+func (s *contentSelectorServiceV382) DeleteContentSelector(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.ContentSelectorsAPI.DeleteContentSelector(ctx, name).Execute()
+}
+
+func (s *contentSelectorServiceV382) GetContentSelectors(ctx context.Context) ([]sonatyperepoV382.ContentSelectorApiResponse, *http.Response, error) {
+	return s.client.ContentSelectorsAPI.GetContentSelectors(ctx).Execute()
+}
+
+// contentSelectorServiceV395 implements ContentSelectorService against NXRM API client V395 (targets NXRM 3.94.0+).
+// Requests/responses are bridged to/from V382 shapes via JSON, since the internal/provider/model
+// package's mapping methods are written in terms of V382 types.
+//
+// Field differences requiring explicit patching:
+//   - ContentSelectorApiCreateRequest.Name and Expression changed from *string (V382) to string (V395).
+//     jsonBridge handles this transparently for reads. For writes, we bridge and then manually
+//     populate non-nil required fields from the V382 struct's optional fields.
+//   - ContentSelectorApiUpdateRequest.Expression changed from *string (V382) to string (V395).
+//     Handled similarly on writes.
+type contentSelectorServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *contentSelectorServiceV395) CreateContentSelector(ctx context.Context, body sonatyperepoV382.ContentSelectorApiCreateRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ContentSelectorApiCreateRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	// Patch required fields: Name and Expression changed from *string (V382) to string (V395)
+	if body.Name != nil {
+		v395Body.Name = *body.Name
+	}
+	if body.Expression != nil {
+		v395Body.Expression = *body.Expression
+	}
+
+	return s.client.ContentSelectorsAPI.CreateSecurityContentSelectors(ctx).ContentSelectorApiCreateRequest(v395Body).Execute()
+}
+
+func (s *contentSelectorServiceV395) GetContentSelector(ctx context.Context, name string) (*sonatyperepoV382.ContentSelectorApiResponse, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.ContentSelectorsAPI.GetSecurityContentSelectors(ctx, name).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.ContentSelectorApiResponse
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *contentSelectorServiceV395) UpdateContentSelector(ctx context.Context, name string, body sonatyperepoV382.ContentSelectorApiUpdateRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ContentSelectorApiUpdateRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	// Patch required field: Expression changed from *string (V382) to string (V395)
+	if body.Expression != nil {
+		v395Body.Expression = *body.Expression
+	}
+
+	return s.client.ContentSelectorsAPI.UpdateSecurityContentSelectors(ctx, name).ContentSelectorApiUpdateRequest(v395Body).Execute()
+}
+
+func (s *contentSelectorServiceV395) DeleteContentSelector(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.ContentSelectorsAPI.DeleteSecurityContentSelectors(ctx, name).Execute()
+}
+
+func (s *contentSelectorServiceV395) GetContentSelectors(ctx context.Context) ([]sonatyperepoV382.ContentSelectorApiResponse, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.ContentSelectorsAPI.ListSecurityContentSelectors(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result []sonatyperepoV382.ContentSelectorApiResponse
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return result, httpResponse, nil
+}

--- a/internal/provider/common/context.go
+++ b/internal/provider/common/context.go
@@ -18,7 +18,9 @@ package common
 
 import (
 	"context"
+
 	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
 )
 
 // AuthContext represents the authentication information needed for API calls
@@ -33,10 +35,20 @@ func NewAuthContext(auth sonatyperepo.BasicAuth) *AuthContext {
 
 // WithAuthContext adds authentication to the context for API calls
 func WithAuthContext(ctx context.Context, authCtx *AuthContext) context.Context {
-	return context.WithValue(ctx, sonatyperepo.ContextBasicAuth, authCtx.Auth)
+	return WithAuth(ctx, authCtx.Auth)
 }
 
-// WithAuth adds authentication directly from BasicAuth
+// WithAuth adds authentication directly from BasicAuth. The generated V382 and V395
+// clients each define their own private contextKey type with the same underlying
+// value ("basic"), but context.Value lookups compare dynamic type as well as value,
+// so a key from one generation's package never matches a value stored under the
+// other's. Both keys are set here so a single context works with whichever client
+// generation's adapter ultimately executes the request.
 func WithAuth(ctx context.Context, auth sonatyperepo.BasicAuth) context.Context {
-	return context.WithValue(ctx, sonatyperepo.ContextBasicAuth, auth)
+	ctx = context.WithValue(ctx, sonatyperepo.ContextBasicAuth, auth)
+	ctx = context.WithValue(ctx, sonatyperepoV395.ContextBasicAuth, sonatyperepoV395.BasicAuth{
+		UserName: auth.UserName,
+		Password: auth.Password,
+	})
+	return ctx
 }

--- a/internal/provider/common/data_source.go
+++ b/internal/provider/common/data_source.go
@@ -33,8 +33,9 @@ var (
 
 // BaseDataSource is the data source implementation.
 type BaseDataSource struct {
-	Auth   sonatyperepo.BasicAuth
-	Client *sonatyperepo.APIClient
+	Auth     sonatyperepo.BasicAuth
+	Client   *sonatyperepo.APIClient
+	Services Services
 }
 
 // Configure implements datasource.DataSourceWithConfigure.
@@ -55,6 +56,7 @@ func (d *BaseDataSource) Configure(_ context.Context, req datasource.ConfigureRe
 
 	d.Auth = config.Auth
 	d.Client = config.Client
+	d.Services = config.Services
 }
 
 // AuthContext returns a new context with authentication set up for API calls

--- a/internal/provider/common/http_settings_service.go
+++ b/internal/provider/common/http_settings_service.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// HttpSettingsService abstracts the HTTP System Settings API across NXRM API client generations.
+type HttpSettingsService interface {
+	// GetHttpSettings retrieves current HTTP system settings.
+	GetHttpSettings(ctx context.Context) (*sonatyperepoV382.HttpSettingsXo, *http.Response, error)
+	// ResetHttpSettings resets HTTP system settings to defaults.
+	ResetHttpSettings(ctx context.Context) (*http.Response, error)
+	// UpdateHttpSettings updates HTTP system settings.
+	UpdateHttpSettings(ctx context.Context, body sonatyperepoV382.HttpSettingsXo) (*http.Response, error)
+}
+
+// httpSettingsServiceV382 implements HttpSettingsService against NXRM API client V382 (targets NXRM < 3.94.0).
+type httpSettingsServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *httpSettingsServiceV382) GetHttpSettings(ctx context.Context) (*sonatyperepoV382.HttpSettingsXo, *http.Response, error) {
+	return s.client.ManageSonatypeHTTPSystemSettingsAPI.GetHttpSettings(ctx).Execute()
+}
+
+func (s *httpSettingsServiceV382) ResetHttpSettings(ctx context.Context) (*http.Response, error) {
+	return s.client.ManageSonatypeHTTPSystemSettingsAPI.ResetHttpSettings(ctx).Execute()
+}
+
+func (s *httpSettingsServiceV382) UpdateHttpSettings(ctx context.Context, body sonatyperepoV382.HttpSettingsXo) (*http.Response, error) {
+	return s.client.ManageSonatypeHTTPSystemSettingsAPI.UpdateHttpSettings(ctx).Body(body).Execute()
+}
+
+// httpSettingsServiceV395 implements HttpSettingsService against NXRM API client V395 (targets NXRM 3.94.0+).
+type httpSettingsServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *httpSettingsServiceV395) GetHttpSettings(ctx context.Context) (*sonatyperepoV382.HttpSettingsXo, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.ManageSonatypeHTTPSystemSettingsAPI.ListHttp(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 response to V382 shape
+	var v382Response sonatyperepoV382.HttpSettingsXo
+	if err := jsonBridge(v395Response, &v382Response); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &v382Response, httpResponse, nil
+}
+
+func (s *httpSettingsServiceV395) ResetHttpSettings(ctx context.Context) (*http.Response, error) {
+	return s.client.ManageSonatypeHTTPSystemSettingsAPI.DeleteHttp(ctx).Execute()
+}
+
+func (s *httpSettingsServiceV395) UpdateHttpSettings(ctx context.Context, body sonatyperepoV382.HttpSettingsXo) (*http.Response, error) {
+	// Bridge V382 request to V395 shape
+	var v395Body sonatyperepoV395.HttpSettingsXo
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+
+	return s.client.ManageSonatypeHTTPSystemSettingsAPI.UpdateHttp(ctx).HttpSettingsXo(v395Body).Execute()
+}
+
+// NewHttpSettingsServiceV382 creates a V382 HttpSettingsService adapter.
+func NewHttpSettingsServiceV382(client *sonatyperepoV382.APIClient) HttpSettingsService {
+	return &httpSettingsServiceV382{client: client}
+}
+
+// NewHttpSettingsServiceV395 creates a V395 HttpSettingsService adapter.
+func NewHttpSettingsServiceV395(client *sonatyperepoV395.APIClient) HttpSettingsService {
+	return &httpSettingsServiceV395{client: client}
+}

--- a/internal/provider/common/json_bridge.go
+++ b/internal/provider/common/json_bridge.go
@@ -67,7 +67,7 @@ func bridgeFromResponse(apiSrc any, httpResponse *http.Response, err error, dst 
 	}
 
 	body, readErr := io.ReadAll(httpResponse.Body)
-	httpResponse.Body.Close()
+	_ = httpResponse.Body.Close()
 	if readErr != nil {
 		return err
 	}

--- a/internal/provider/common/json_bridge.go
+++ b/internal/provider/common/json_bridge.go
@@ -38,7 +38,7 @@ import (
 // (recursively, at every nesting level) down to the field names dst's type actually declares --
 // otherwise a field that only exists on the src side (e.g. a newer generation added a field)
 // would fail the whole decode with "json: unknown field ...".
-func jsonBridge(src any, dst any) error {
+func jsonBridge(src, dst any) error {
 	b, err := json.Marshal(src)
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func bridgeFromResponse(apiSrc any, httpResponse *http.Response, err error, dst 
 	if pruneErr != nil {
 		return err
 	}
-	if unmarshalErr := json.Unmarshal(pruned, dst); unmarshalErr != nil {
+	if json.Unmarshal(pruned, dst) != nil {
 		return err
 	}
 	return nil
@@ -87,9 +87,7 @@ func bridgeFromResponse(apiSrc any, httpResponse *http.Response, err error, dst 
 // (by JSON tag) on t, descending into nested objects/arrays along the way. Types it can't
 // reason about (maps, interfaces, scalars) are passed through unchanged.
 func pruneUnknownJSONFields(raw json.RawMessage, t reflect.Type) (json.RawMessage, error) {
-	for t != nil && t.Kind() == reflect.Ptr {
-		t = t.Elem()
-	}
+	t = indirect(t)
 	if t == nil {
 		return raw, nil
 	}
@@ -107,58 +105,74 @@ func pruneUnknownJSONFields(raw json.RawMessage, t reflect.Type) (json.RawMessag
 
 	switch t.Kind() {
 	case reflect.Struct:
-		var obj map[string]json.RawMessage
-		if err := json.Unmarshal(raw, &obj); err != nil {
-			// Not a JSON object (e.g. null, or a mismatched shape) -- leave it for the
-			// real unmarshal to accept or reject.
-			return raw, nil
-		}
-		known := jsonFieldTypes(t)
-		for key, val := range obj {
-			fieldType, ok := known[key]
-			if !ok {
-				delete(obj, key)
-				continue
-			}
-			prunedVal, err := pruneUnknownJSONFields(val, fieldType)
-			if err != nil {
-				return nil, err
-			}
-			obj[key] = prunedVal
-		}
-		// Some generated structs manually check that every declared field is present as a
-		// JSON key before decoding, even when the field's Go type has a perfectly usable
-		// zero value (e.g. a bool). If the source generation dropped a field the destination
-		// still declares -- a version-skew removal, not just an encoding difference -- that
-		// check fails the whole decode unless we backfill the zero value ourselves.
-		for key, fieldType := range known {
-			if _, exists := obj[key]; exists {
-				continue
-			}
-			if zero, ok := zeroJSONValue(fieldType); ok {
-				obj[key] = zero
-			}
-		}
-		return json.Marshal(obj)
-
+		return pruneStructFields(raw, t)
 	case reflect.Slice, reflect.Array:
-		var arr []json.RawMessage
-		if err := json.Unmarshal(raw, &arr); err != nil {
-			return raw, nil
-		}
-		elemType := t.Elem()
-		for i, v := range arr {
-			prunedVal, err := pruneUnknownJSONFields(v, elemType)
-			if err != nil {
-				return nil, err
-			}
-			arr[i] = prunedVal
-		}
-		return json.Marshal(arr)
-
+		return pruneSliceElements(raw, t.Elem())
 	default:
 		return raw, nil
 	}
+}
+
+// indirect strips pointer indirection, following it all the way down to the underlying type.
+func indirect(t reflect.Type) reflect.Type {
+	for t != nil && t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t
+}
+
+// pruneStructFields drops object keys that have no corresponding field (by JSON tag) on t,
+// recursing into each retained field's value, and backfills declared fields the object is
+// missing. Not a JSON object (e.g. null, or a mismatched shape) is left for the real unmarshal
+// to accept or reject.
+func pruneStructFields(raw json.RawMessage, t reflect.Type) (json.RawMessage, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw, nil
+	}
+	known := jsonFieldTypes(t)
+	for key, val := range obj {
+		fieldType, ok := known[key]
+		if !ok {
+			delete(obj, key)
+			continue
+		}
+		prunedVal, err := pruneUnknownJSONFields(val, fieldType)
+		if err != nil {
+			return nil, err
+		}
+		obj[key] = prunedVal
+	}
+	// Some generated structs manually check that every declared field is present as a
+	// JSON key before decoding, even when the field's Go type has a perfectly usable
+	// zero value (e.g. a bool). If the source generation dropped a field the destination
+	// still declares -- a version-skew removal, not just an encoding difference -- that
+	// check fails the whole decode unless we backfill the zero value ourselves.
+	for key, fieldType := range known {
+		if _, exists := obj[key]; exists {
+			continue
+		}
+		if zero, ok := zeroJSONValue(fieldType); ok {
+			obj[key] = zero
+		}
+	}
+	return json.Marshal(obj)
+}
+
+// pruneSliceElements applies pruneUnknownJSONFields to every element of a JSON array.
+func pruneSliceElements(raw json.RawMessage, elemType reflect.Type) (json.RawMessage, error) {
+	var arr []json.RawMessage
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return raw, nil
+	}
+	for i, v := range arr {
+		prunedVal, err := pruneUnknownJSONFields(v, elemType)
+		if err != nil {
+			return nil, err
+		}
+		arr[i] = prunedVal
+	}
+	return json.Marshal(arr)
 }
 
 // nullableElemType detects the generated client's "NullableXxx" wrapper shape --
@@ -209,35 +223,44 @@ func jsonFieldTypes(t reflect.Type) map[string]reflect.Type {
 	fields := make(map[string]reflect.Type)
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
-
 		if f.Anonymous {
-			embedded := f.Type
-			for embedded.Kind() == reflect.Ptr {
-				embedded = embedded.Elem()
-			}
-			if embedded.Kind() == reflect.Struct {
-				for k, v := range jsonFieldTypes(embedded) {
-					fields[k] = v
-				}
-			}
+			mergeEmbeddedFieldTypes(fields, f.Type)
 			continue
 		}
-
-		tag := f.Tag.Get("json")
-		if tag == "-" {
-			continue
+		if name, ok := jsonFieldName(f); ok {
+			fields[name] = f.Type
 		}
-		name := f.Name
-		if tag != "" {
-			if idx := strings.Index(tag, ","); idx >= 0 {
-				if tag[:idx] != "" {
-					name = tag[:idx]
-				}
-			} else {
-				name = tag
-			}
-		}
-		fields[name] = f.Type
 	}
 	return fields
+}
+
+// mergeEmbeddedFieldTypes merges the JSON field types of an anonymous (embedded) struct field
+// into fields, so promoted fields are addressable by their own JSON key.
+func mergeEmbeddedFieldTypes(fields map[string]reflect.Type, embedded reflect.Type) {
+	embedded = indirect(embedded)
+	if embedded == nil || embedded.Kind() != reflect.Struct {
+		return
+	}
+	for k, v := range jsonFieldTypes(embedded) {
+		fields[k] = v
+	}
+}
+
+// jsonFieldName returns the JSON key f would decode from, and false if it's excluded via
+// a `json:"-"` tag.
+func jsonFieldName(f reflect.StructField) (string, bool) {
+	tag := f.Tag.Get("json")
+	if tag == "-" {
+		return "", false
+	}
+	if tag == "" {
+		return f.Name, true
+	}
+	if idx := strings.Index(tag, ","); idx >= 0 {
+		if tag[:idx] != "" {
+			return tag[:idx], true
+		}
+		return f.Name, true
+	}
+	return tag, true
 }

--- a/internal/provider/common/json_bridge.go
+++ b/internal/provider/common/json_bridge.go
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+)
+
+// jsonBridge re-shapes a struct from one NXRM API client generation into the equivalent
+// struct of another generation via a JSON round-trip. This is safe because every field
+// that exists in both generations shares the same JSON tag; fields that only exist on one
+// side are silently dropped (write) or left at their zero value (read). Known same-named-
+// field renames (e.g. RoutingRule -> RoutingRuleName) must be patched explicitly by the
+// caller after this bridge runs. Used by every domain service adapter that canonicalizes
+// V395 responses/requests into the V382 generated shape the model-mapping layer expects.
+//
+// Generated structs commonly have a custom UnmarshalJSON that calls decoder.DisallowUnknownFields(),
+// so before the final unmarshal into dst, every JSON object in the marshaled src is pruned
+// (recursively, at every nesting level) down to the field names dst's type actually declares --
+// otherwise a field that only exists on the src side (e.g. a newer generation added a field)
+// would fail the whole decode with "json: unknown field ...".
+func jsonBridge(src any, dst any) error {
+	b, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	pruned, err := pruneUnknownJSONFields(b, reflect.TypeOf(dst))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(pruned, dst)
+}
+
+// bridgeFromResponse populates dst (a pointer) from apiSrc, the already-decoded response of the
+// source generation's own generated client. If the source generation's client itself failed to
+// decode the HTTP response (err != nil) -- which happens when the live server returns a field
+// newer than the vendored client's generated struct declares, a version-skew gap in the client
+// module rather than a real request failure -- and the HTTP call itself succeeded (a response
+// object exists with a non-error status), this falls back to bridging directly from the raw
+// response body instead of giving up. Any other error (network failure, 4xx/5xx status) is
+// returned unchanged.
+func bridgeFromResponse(apiSrc any, httpResponse *http.Response, err error, dst any) error {
+	if err == nil {
+		return jsonBridge(apiSrc, dst)
+	}
+	if httpResponse == nil || httpResponse.StatusCode >= 300 || httpResponse.Body == nil {
+		return err
+	}
+
+	body, readErr := io.ReadAll(httpResponse.Body)
+	httpResponse.Body.Close()
+	if readErr != nil {
+		return err
+	}
+	httpResponse.Body = io.NopCloser(bytes.NewReader(body))
+
+	pruned, pruneErr := pruneUnknownJSONFields(body, reflect.TypeOf(dst))
+	if pruneErr != nil {
+		return err
+	}
+	if unmarshalErr := json.Unmarshal(pruned, dst); unmarshalErr != nil {
+		return err
+	}
+	return nil
+}
+
+// pruneUnknownJSONFields recursively drops object keys that have no corresponding field
+// (by JSON tag) on t, descending into nested objects/arrays along the way. Types it can't
+// reason about (maps, interfaces, scalars) are passed through unchanged.
+func pruneUnknownJSONFields(raw json.RawMessage, t reflect.Type) (json.RawMessage, error) {
+	for t != nil && t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t == nil {
+		return raw, nil
+	}
+
+	// A JSON null must stay null -- unmarshaling it into a map (the struct case below)
+	// succeeds silently with a nil map, which would otherwise fall through to backfilling
+	// every known key with its zero value and fabricate a non-null object in its place.
+	if trimmed := bytes.TrimSpace(raw); string(trimmed) == "null" {
+		return raw, nil
+	}
+
+	if elemType, ok := nullableElemType(t); ok {
+		return pruneUnknownJSONFields(raw, elemType)
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		var obj map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			// Not a JSON object (e.g. null, or a mismatched shape) -- leave it for the
+			// real unmarshal to accept or reject.
+			return raw, nil
+		}
+		known := jsonFieldTypes(t)
+		for key, val := range obj {
+			fieldType, ok := known[key]
+			if !ok {
+				delete(obj, key)
+				continue
+			}
+			prunedVal, err := pruneUnknownJSONFields(val, fieldType)
+			if err != nil {
+				return nil, err
+			}
+			obj[key] = prunedVal
+		}
+		// Some generated structs manually check that every declared field is present as a
+		// JSON key before decoding, even when the field's Go type has a perfectly usable
+		// zero value (e.g. a bool). If the source generation dropped a field the destination
+		// still declares -- a version-skew removal, not just an encoding difference -- that
+		// check fails the whole decode unless we backfill the zero value ourselves.
+		for key, fieldType := range known {
+			if _, exists := obj[key]; exists {
+				continue
+			}
+			if zero, ok := zeroJSONValue(fieldType); ok {
+				obj[key] = zero
+			}
+		}
+		return json.Marshal(obj)
+
+	case reflect.Slice, reflect.Array:
+		var arr []json.RawMessage
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			return raw, nil
+		}
+		elemType := t.Elem()
+		for i, v := range arr {
+			prunedVal, err := pruneUnknownJSONFields(v, elemType)
+			if err != nil {
+				return nil, err
+			}
+			arr[i] = prunedVal
+		}
+		return json.Marshal(arr)
+
+	default:
+		return raw, nil
+	}
+}
+
+// nullableElemType detects the generated client's "NullableXxx" wrapper shape --
+// an unexported `value *Xxx` field alongside an unexported `isSet bool` field -- used
+// throughout both generations for optional/nullable properties. Its custom MarshalJSON/
+// UnmarshalJSON serialize as Xxx directly (or null), not as the wrapper's own two-field
+// Go layout, so pruning must recurse on Xxx rather than reflecting into "value"/"isSet"
+// as if they were the real JSON keys -- otherwise a struct-valued Xxx (e.g. ProxySettingsXo)
+// gets pruned down to nothing, dropping every real field it has.
+func nullableElemType(t reflect.Type) (reflect.Type, bool) {
+	if t.Kind() != reflect.Struct || t.NumField() != 2 {
+		return nil, false
+	}
+	valueField, ok := t.FieldByName("value")
+	if !ok || valueField.Type.Kind() != reflect.Ptr {
+		return nil, false
+	}
+	isSetField, ok := t.FieldByName("isSet")
+	if !ok || isSetField.Type.Kind() != reflect.Bool {
+		return nil, false
+	}
+	return valueField.Type.Elem(), true
+}
+
+// zeroJSONValue returns the JSON encoding of t's zero value, for the scalar kinds where
+// backfilling a missing field is unambiguous and safe. Pointer, struct, slice, and map fields
+// are deliberately left alone -- their "missing" state is either already valid (nil/omitted)
+// or would require recursively synthesizing a nested zero object, which risks masking a real
+// missing-data problem instead of a version-skew one.
+func zeroJSONValue(t reflect.Type) (json.RawMessage, bool) {
+	switch t.Kind() {
+	case reflect.Bool:
+		return json.RawMessage("false"), true
+	case reflect.String:
+		return json.RawMessage(`""`), true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return json.RawMessage("0"), true
+	default:
+		return nil, false
+	}
+}
+
+// jsonFieldTypes maps every JSON key t's fields would decode from to that field's type,
+// merging in the fields of any anonymous (embedded) struct fields.
+func jsonFieldTypes(t reflect.Type) map[string]reflect.Type {
+	fields := make(map[string]reflect.Type)
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+
+		if f.Anonymous {
+			embedded := f.Type
+			for embedded.Kind() == reflect.Ptr {
+				embedded = embedded.Elem()
+			}
+			if embedded.Kind() == reflect.Struct {
+				for k, v := range jsonFieldTypes(embedded) {
+					fields[k] = v
+				}
+			}
+			continue
+		}
+
+		tag := f.Tag.Get("json")
+		if tag == "-" {
+			continue
+		}
+		name := f.Name
+		if tag != "" {
+			if idx := strings.Index(tag, ","); idx >= 0 {
+				if tag[:idx] != "" {
+					name = tag[:idx]
+				}
+			} else {
+				name = tag
+			}
+		}
+		fields[name] = f.Type
+	}
+	return fields
+}

--- a/internal/provider/common/license_service.go
+++ b/internal/provider/common/license_service.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// LicenseService abstracts the Product Licensing API across NXRM API client generations.
+type LicenseService interface {
+	// GetLicenseStatus retrieves current license status.
+	GetLicenseStatus(ctx context.Context) (*sonatyperepoV382.ApiLicenseDetailsXO, *http.Response, error)
+	// RemoveLicense removes the current license.
+	RemoveLicense(ctx context.Context) (*http.Response, error)
+	// SetLicense uploads a new license file.
+	SetLicense(ctx context.Context, licenseFile *os.File) (*sonatyperepoV382.ApiLicenseDetailsXO, *http.Response, error)
+}
+
+// licenseServiceV382 implements LicenseService against NXRM API client V382 (targets NXRM < 3.94.0).
+type licenseServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *licenseServiceV382) GetLicenseStatus(ctx context.Context) (*sonatyperepoV382.ApiLicenseDetailsXO, *http.Response, error) {
+	return s.client.ProductLicensingAPI.GetLicenseStatus(ctx).Execute()
+}
+
+func (s *licenseServiceV382) RemoveLicense(ctx context.Context) (*http.Response, error) {
+	return s.client.ProductLicensingAPI.RemoveLicense(ctx).Execute()
+}
+
+func (s *licenseServiceV382) SetLicense(ctx context.Context, licenseFile *os.File) (*sonatyperepoV382.ApiLicenseDetailsXO, *http.Response, error) {
+	return s.client.ProductLicensingAPI.SetLicense(ctx).Body(licenseFile).Execute()
+}
+
+// licenseServiceV395 implements LicenseService against NXRM API client V395 (targets NXRM 3.94.0+).
+type licenseServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *licenseServiceV395) GetLicenseStatus(ctx context.Context) (*sonatyperepoV382.ApiLicenseDetailsXO, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.ProductLicensingAPI.ListSystemLicense(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 response to V382 shape
+	var v382Response sonatyperepoV382.ApiLicenseDetailsXO
+	if err := jsonBridge(v395Response, &v382Response); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &v382Response, httpResponse, nil
+}
+
+func (s *licenseServiceV395) RemoveLicense(ctx context.Context) (*http.Response, error) {
+	return s.client.ProductLicensingAPI.DeleteSystemLicense(ctx).Execute()
+}
+
+// SetLicense cannot currently transmit the license file's bytes to a V395 server: the
+// upstream OpenAPI spec (nexus-repo-api-client, POST /v1/system/license) declares the
+// application/octet-stream request body as `schema: type: object`, so the Go generator
+// emits CreateSystemLicense's body param as map[string]interface{} rather than a binary
+// payload (*os.File/[]byte). The generated client's setBody() only serializes
+// io.Reader/*os.File/[]byte/string or JSON-content-typed bodies, none of which match here,
+// so any call to CreateSystemLicenseExecute fails with "invalid body type
+// application/octet-stream" regardless of what is passed. Fixing this requires correcting
+// the spec to `type: string, format: binary` and regenerating the V395 client in the
+// sibling nexus-repo-api-client repo; licenseFile is accepted here to satisfy the
+// LicenseService interface and is intentionally unused until that upstream fix lands.
+func (s *licenseServiceV395) SetLicense(ctx context.Context, licenseFile *os.File) (*sonatyperepoV382.ApiLicenseDetailsXO, *http.Response, error) {
+	_ = licenseFile
+	v395Response, httpResponse, err := s.client.ProductLicensingAPI.CreateSystemLicense(ctx).Body(map[string]interface{}{}).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 response to V382 shape
+	var v382Response sonatyperepoV382.ApiLicenseDetailsXO
+	if err := jsonBridge(v395Response, &v382Response); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &v382Response, httpResponse, nil
+}
+
+// NewLicenseServiceV382 creates a V382 LicenseService adapter.
+func NewLicenseServiceV382(client *sonatyperepoV382.APIClient) LicenseService {
+	return &licenseServiceV382{client: client}
+}
+
+// NewLicenseServiceV395 creates a V395 LicenseService adapter.
+func NewLicenseServiceV395(client *sonatyperepoV395.APIClient) LicenseService {
+	return &licenseServiceV395{client: client}
+}

--- a/internal/provider/common/model.go
+++ b/internal/provider/common/model.go
@@ -177,6 +177,21 @@ func (s *SystemVersion) SupportsCapabilities() bool {
 	return s.NewerThan(3, 84, 0, 0)
 }
 
+func (s *SystemVersion) SupportsInlineFirewall() bool {
+	return s.NewerThan(3, 94, 0, 0)
+}
+
+// FirewallMode represents the inline `firewall.mode` value supported by NXRM 3.94+
+// proxy repository APIs, replacing the separate Capability-based firewall configuration.
+type FirewallMode string
+
+const (
+	FirewallModeDisabled   FirewallMode = "DISABLED"
+	FirewallModeAudit      FirewallMode = "AUDIT"
+	FirewallModeQuarantine FirewallMode = "QUARANTINE"
+	FirewallModePccs       FirewallMode = "PCCS"
+)
+
 func ParseServerHeaderToVersion(headerStr string) SystemVersion {
 	match := FindAllGroups(nxrmServerVersionExp, strings.ToUpper(headerStr))
 	sysVersion := SystemVersion{}

--- a/internal/provider/common/model.go
+++ b/internal/provider/common/model.go
@@ -38,6 +38,7 @@ type SonatypeDataSourceData struct {
 	NodeCount                     int32
 	NxrmVersion                   SystemVersion
 	NxrmWritable                  bool
+	Services                      Services
 }
 
 // AuthContext returns a new context with authentication set up for API calls
@@ -46,6 +47,8 @@ func (r *SonatypeDataSourceData) AuthContext(ctx context.Context) context.Contex
 }
 
 func (p *SonatypeDataSourceData) ClusterNodeCount(ctx context.Context, respDiags *diag.Diagnostics) {
+	// This runs during provider bootstrap, before NxrmVersion is known and before
+	// Services exists, so it must call the bootstrap (V382) client directly.
 	apiResponse, httpResponse, err := p.Client.StatusAPI.GetClusterSystemStatusChecks(p.AuthContext(ctx)).Execute()
 
 	if err != nil {
@@ -74,6 +77,8 @@ func (p *SonatypeDataSourceData) ClusterNodeCount(ctx context.Context, respDiags
 }
 
 func (p *SonatypeDataSourceData) CheckWritableAndGetVersion(ctx context.Context, respDiags *diag.Diagnostics, versionHint *string) {
+	// This runs during provider bootstrap, before NxrmVersion is known and before
+	// Services exists, so it must call the bootstrap (V382) client directly.
 	httpResponse, err := p.Client.StatusAPI.IsWritable(ctx).Execute()
 	if err != nil {
 		sharederr.HandleAPIError(

--- a/internal/provider/common/privilege_service.go
+++ b/internal/provider/common/privilege_service.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// PrivilegeService abstracts the Security Management Privileges API across NXRM API client generations.
+type PrivilegeService interface {
+	// GetAllPrivileges retrieves a list of all privileges.
+	GetAllPrivileges(ctx context.Context) ([]sonatyperepoV382.ApiPrivilegeRequest, *http.Response, error)
+}
+
+// privilegeServiceV382 implements PrivilegeService against NXRM API client V382 (targets NXRM < 3.94.0).
+type privilegeServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *privilegeServiceV382) GetAllPrivileges(ctx context.Context) ([]sonatyperepoV382.ApiPrivilegeRequest, *http.Response, error) {
+	return s.client.SecurityManagementPrivilegesAPI.GetAllPrivileges(ctx).Execute()
+}
+
+// privilegeServiceV395 implements PrivilegeService against NXRM API client V395 (targets NXRM 3.94.0+).
+type privilegeServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *privilegeServiceV395) GetAllPrivileges(ctx context.Context) ([]sonatyperepoV382.ApiPrivilegeRequest, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.SecurityManagementPrivilegesAPI.GetAllPrivileges(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result []sonatyperepoV382.ApiPrivilegeRequest
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return result, httpResponse, nil
+}

--- a/internal/provider/common/realms_service.go
+++ b/internal/provider/common/realms_service.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// RealmsService abstracts security realms API across NXRM API client generations.
+type RealmsService interface {
+	GetActiveRealms(ctx context.Context) ([]string, *http.Response, error)
+	SetActiveRealms(ctx context.Context, activeRealms []string) (*http.Response, error)
+}
+
+// realmsServiceV382 implements RealmsService against NXRM API client V382 (targets NXRM < 3.94.0).
+type realmsServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func NewRealmsServiceV382(client *sonatyperepoV382.APIClient) RealmsService {
+	return &realmsServiceV382{client: client}
+}
+
+func (s *realmsServiceV382) GetActiveRealms(ctx context.Context) ([]string, *http.Response, error) {
+	return s.client.SecurityManagementRealmsAPI.GetActiveRealms(ctx).Execute()
+}
+
+func (s *realmsServiceV382) SetActiveRealms(ctx context.Context, activeRealms []string) (*http.Response, error) {
+	return s.client.SecurityManagementRealmsAPI.SetActiveRealms(ctx).Body(activeRealms).Execute()
+}
+
+// realmsServiceV395 implements RealmsService against NXRM API client V395 (targets NXRM 3.94.0+).
+type realmsServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func NewRealmsServiceV395(client *sonatyperepoV395.APIClient) RealmsService {
+	return &realmsServiceV395{client: client}
+}
+
+func (s *realmsServiceV395) GetActiveRealms(ctx context.Context) ([]string, *http.Response, error) {
+	return s.client.SecurityManagementRealmsAPI.ListSecurityRealmsActive(ctx).Execute()
+}
+
+func (s *realmsServiceV395) SetActiveRealms(ctx context.Context, activeRealms []string) (*http.Response, error) {
+	return s.client.SecurityManagementRealmsAPI.UpdateSecurityRealmsActive(ctx).RequestBody(activeRealms).Execute()
+}

--- a/internal/provider/common/repository_management_service.go
+++ b/internal/provider/common/repository_management_service.go
@@ -40,9 +40,9 @@ type RepositoryManagementService interface {
 	CreateAlpineHostedRepository(ctx context.Context, body sonatyperepoV382.AlpineHostedRepositoryApiRequest) (*http.Response, error)
 	GetAlpineHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineHostedApiRepository, *http.Response, error)
 	UpdateAlpineHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineHostedRepositoryApiRequest) (*http.Response, error)
-	CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error)
-	GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *http.Response, error)
-	UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error)
+	CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateAnsiblegalaxyGroupRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyGroupRepositoryApiRequest) (*http.Response, error)
 	GetAnsiblegalaxyGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyGroupApiRepository, *http.Response, error)
 	UpdateAnsiblegalaxyGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyGroupRepositoryApiRequest) (*http.Response, error)
@@ -64,15 +64,15 @@ type RepositoryManagementService interface {
 	CreateCargoHostedRepository(ctx context.Context, body sonatyperepoV382.CargoHostedRepositoryApiRequest) (*http.Response, error)
 	GetCargoHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdateCargoHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoHostedRepositoryApiRequest) (*http.Response, error)
-	CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error)
-	GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *http.Response, error)
-	UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error)
+	CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error)
 	GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
 	UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error)
-	CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error)
-	GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
-	UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error)
+	CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error)
+	UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateConanGroupRepository(ctx context.Context, body sonatyperepoV382.ConanGroupRepositoryApiRequest) (*http.Response, error)
 	GetConanGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error)
 	UpdateConanGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanGroupRepositoryApiRequest) (*http.Response, error)
@@ -91,9 +91,9 @@ type RepositoryManagementService interface {
 	CreateDockerHostedRepository(ctx context.Context, body sonatyperepoV382.DockerHostedRepositoryApiRequest) (*http.Response, error)
 	GetDockerHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerHostedApiRepository, *http.Response, error)
 	UpdateDockerHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerHostedRepositoryApiRequest) (*http.Response, error)
-	CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error)
-	GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *http.Response, error)
-	UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error)
+	CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateGitlfsHostedRepository(ctx context.Context, body sonatyperepoV382.GitLfsHostedRepositoryApiRequest) (*http.Response, error)
 	GetGitlfsHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdateGitlfsHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GitLfsHostedRepositoryApiRequest) (*http.Response, error)
@@ -103,9 +103,9 @@ type RepositoryManagementService interface {
 	CreateGoHostedRepository(ctx context.Context, body sonatyperepoV382.GolangHostedRepositoryApiRequest) (*http.Response, error)
 	GetGoHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdateGoHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangHostedRepositoryApiRequest) (*http.Response, error)
-	CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error)
-	GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
-	UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error)
+	CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error)
+	UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateHelmGroupRepository(ctx context.Context, body sonatyperepoV382.HelmGroupRepositoryApiRequest) (*http.Response, error)
 	GetHelmGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
 	UpdateHelmGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmGroupRepositoryApiRequest) (*http.Response, error)
@@ -115,9 +115,9 @@ type RepositoryManagementService interface {
 	CreateHelmProxyRepository(ctx context.Context, body sonatyperepoV382.HelmProxyRepositoryApiRequest) (*http.Response, error)
 	GetHelmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
 	UpdateHelmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmProxyRepositoryApiRequest) (*http.Response, error)
-	CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error)
-	GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
-	UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error)
+	CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error)
+	UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateMavenGroupRepository(ctx context.Context, body sonatyperepoV382.MavenGroupRepositoryApiRequest) (*http.Response, error)
 	GetMavenGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
 	UpdateMavenGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenGroupRepositoryApiRequest) (*http.Response, error)
@@ -133,9 +133,9 @@ type RepositoryManagementService interface {
 	CreateNpmHostedRepository(ctx context.Context, body sonatyperepoV382.NpmHostedRepositoryApiRequest) (*http.Response, error)
 	GetNpmHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdateNpmHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmHostedRepositoryApiRequest) (*http.Response, error)
-	CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error)
-	GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *http.Response, error)
-	UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error)
+	CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateNugetGroupRepository(ctx context.Context, body sonatyperepoV382.NugetGroupRepositoryApiRequest) (*http.Response, error)
 	GetNugetGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
 	UpdateNugetGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetGroupRepositoryApiRequest) (*http.Response, error)
@@ -154,18 +154,18 @@ type RepositoryManagementService interface {
 	CreatePypiHostedRepository(ctx context.Context, body sonatyperepoV382.PypiHostedRepositoryApiRequest) (*http.Response, error)
 	GetPypiHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdatePypiHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiHostedRepositoryApiRequest) (*http.Response, error)
-	CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error)
-	GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *http.Response, error)
-	UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error)
+	CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateRGroupRepository(ctx context.Context, body sonatyperepoV382.RGroupRepositoryApiRequest) (*http.Response, error)
 	GetRGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
 	UpdateRGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RGroupRepositoryApiRequest) (*http.Response, error)
 	CreateRHostedRepository(ctx context.Context, body sonatyperepoV382.RHostedRepositoryApiRequest) (*http.Response, error)
 	GetRHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdateRHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RHostedRepositoryApiRequest) (*http.Response, error)
-	CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error)
-	GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
-	UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error)
+	CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error)
+	UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateRawGroupRepository(ctx context.Context, body sonatyperepoV382.RawGroupRepositoryApiRequest) (*http.Response, error)
 	GetRawGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawGroupApiRepository, *http.Response, error)
 	UpdateRawGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawGroupRepositoryApiRequest) (*http.Response, error)
@@ -249,15 +249,16 @@ func (s *repositoryManagementServiceV382) UpdateAlpineHostedRepository(ctx conte
 	return s.client.RepositoryManagementAPI.UpdateAlpineHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateAlpineProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetAlpineProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetAlpineProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateAlpineProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -345,15 +346,16 @@ func (s *repositoryManagementServiceV382) UpdateCargoHostedRepository(ctx contex
 	return s.client.RepositoryManagementAPI.UpdateCargoHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateCargoProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetCargoProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *FirewallMode, *http.Response, error) {
+	result, httpResponse, err := s.client.RepositoryManagementAPI.GetCargoProxyRepository(ctx, repositoryName).Execute()
+	return result, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateCargoProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -369,15 +371,16 @@ func (s *repositoryManagementServiceV382) UpdateCocoapodsProxyRepository(ctx con
 	return s.client.RepositoryManagementAPI.UpdateCocoapodsProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateComposerProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetComposerProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetComposerProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateComposerProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -453,15 +456,16 @@ func (s *repositoryManagementServiceV382) UpdateDockerHostedRepository(ctx conte
 	return s.client.RepositoryManagementAPI.UpdateDockerHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateDockerProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetDockerProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetDockerProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateDockerProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -501,15 +505,16 @@ func (s *repositoryManagementServiceV382) UpdateGoHostedRepository(ctx context.C
 	return s.client.RepositoryManagementAPI.UpdateGoHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateGoProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetGoProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
+	result, httpResponse, err := s.client.RepositoryManagementAPI.GetGoProxyRepository(ctx, repositoryName).Execute()
+	return result, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateGoProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -549,15 +554,16 @@ func (s *repositoryManagementServiceV382) UpdateHelmProxyRepository(ctx context.
 	return s.client.RepositoryManagementAPI.UpdateHelmProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateHuggingfaceProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetHuggingfaceProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
+	result, httpResponse, err := s.client.RepositoryManagementAPI.GetHuggingfaceProxyRepository(ctx, repositoryName).Execute()
+	return result, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateHuggingfaceProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -621,15 +627,16 @@ func (s *repositoryManagementServiceV382) UpdateNpmHostedRepository(ctx context.
 	return s.client.RepositoryManagementAPI.UpdateNpmHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateNpmProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetNpmProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *FirewallMode, *http.Response, error) {
+	api, httpResp, err := s.client.RepositoryManagementAPI.GetNpmProxyRepository(ctx, repositoryName).Execute()
+	return api, nil, httpResp, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateNpmProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -705,15 +712,16 @@ func (s *repositoryManagementServiceV382) UpdatePypiHostedRepository(ctx context
 	return s.client.RepositoryManagementAPI.UpdatePypiHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreatePypiProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetPypiProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetPypiProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdatePypiProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -741,15 +749,16 @@ func (s *repositoryManagementServiceV382) UpdateRHostedRepository(ctx context.Co
 	return s.client.RepositoryManagementAPI.UpdateRHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateRProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetRProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetRProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateRProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -1008,33 +1017,43 @@ func (s *repositoryManagementServiceV395) UpdateAlpineHostedRepository(ctx conte
 	return s.client.RepositoryManagementAPI.UpdateAlpineHostedRepository(ctx, repositoryName).AlpineHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.AlpineProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateAlpineProxyRepository(ctx).AlpineProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAlpineProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.AlpineProxyApiRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.AlpineProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateAlpineProxyRepository(ctx, repositoryName).AlpineProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -1238,33 +1257,43 @@ func (s *repositoryManagementServiceV395) UpdateCargoHostedRepository(ctx contex
 	return s.client.RepositoryManagementAPI.UpdateCargoHostedRepository(ctx, repositoryName).CargoHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.CargoProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateCargoProxyRepository(ctx).CargoProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetCargoProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil && apiV395.Firewall.Mode != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.CargoProxyApiRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.CargoProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateCargoProxyRepository(ctx, repositoryName).CargoProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -1298,33 +1327,43 @@ func (s *repositoryManagementServiceV395) UpdateCocoapodsProxyRepository(ctx con
 	return s.client.RepositoryManagementAPI.UpdateCocoapodsProxyRepository(ctx, repositoryName).CocoapodsProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.ComposerProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateComposerProxyRepository(ctx).ComposerProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetComposerProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.SimpleApiProxyRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.ComposerProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateComposerProxyRepository(ctx, repositoryName).ComposerProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -1500,33 +1539,43 @@ func (s *repositoryManagementServiceV395) UpdateDockerHostedRepository(ctx conte
 	return s.client.RepositoryManagementAPI.UpdateDockerHostedRepository(ctx, repositoryName).DockerHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.DockerProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateDockerProxyRepository(ctx).DockerProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetDockerProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil && apiV395.Firewall.Mode != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.DockerProxyApiRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.DockerProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateDockerProxyRepository(ctx, repositoryName).DockerProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -1614,33 +1663,43 @@ func (s *repositoryManagementServiceV395) UpdateGoHostedRepository(ctx context.C
 	return s.client.RepositoryManagementAPI.UpdateGoHostedRepository(ctx, repositoryName).GolangHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.GolangProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateGoProxyRepository(ctx).GolangProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetGoProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil && apiV395.Firewall.Mode != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.SimpleApiProxyRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.GolangProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateGoProxyRepository(ctx, repositoryName).GolangProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -1730,33 +1789,43 @@ func (s *repositoryManagementServiceV395) UpdateHelmProxyRepository(ctx context.
 	return s.client.RepositoryManagementAPI.UpdateHelmProxyRepository(ctx, repositoryName).HelmProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.HuggingFaceProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateHuggingfaceProxyRepository(ctx).HuggingFaceProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetHuggingfaceProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil && apiV395.Firewall.Mode != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.SimpleApiProxyRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.HuggingFaceProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateHuggingfaceProxyRepository(ctx, repositoryName).HuggingFaceProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -1902,33 +1971,44 @@ func (s *repositoryManagementServiceV395) UpdateNpmHostedRepository(ctx context.
 	return s.client.RepositoryManagementAPI.UpdateNpmHostedRepository(ctx, repositoryName).NpmHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.NpmProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateNpmProxyRepository(ctx).NpmProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetNpmProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
 	var result sonatyperepoV382.NpmProxyApiRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	var mode *FirewallMode
+	if apiV395.Firewall != nil && apiV395.Firewall.Mode != nil {
+		m := FirewallMode(*apiV395.Firewall.Mode)
+		mode = &m
+	}
+	return &result, mode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.NpmProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateNpmProxyRepository(ctx, repositoryName).NpmProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -2104,30 +2184,39 @@ func (s *repositoryManagementServiceV395) UpdatePypiHostedRepository(ctx context
 	return s.client.RepositoryManagementAPI.UpdatePypiHostedRepository(ctx, repositoryName).PypiHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.PypiProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreatePypiProxyRepository(ctx).PypiProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetPypiProxyRepository(ctx, repositoryName).Execute()
 	var result sonatyperepoV382.PyPiProxyApiRepository
 	if err := bridgeFromResponse(apiV395, httpResponse, err, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	// v395.95.0's PyPiProxyApiRepository response type has no Firewall field (unlike its
+	// request-type counterpart, and unlike every other proxy format's response type), so the
+	// mode cannot be read back for PyPI via this endpoint.
+	return &result, nil, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.PypiProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdatePypiProxyRepository(ctx, repositoryName).PypiProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -2187,33 +2276,43 @@ func (s *repositoryManagementServiceV395) UpdateRHostedRepository(ctx context.Co
 	return s.client.RepositoryManagementAPI.UpdateRHostedRepository(ctx, repositoryName).RHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.RProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateRProxyRepository(ctx).RProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.SimpleApiProxyRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.RProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateRProxyRepository(ctx, repositoryName).RProxyRepositoryApiRequest(v395Body).Execute()
 }
 

--- a/internal/provider/common/repository_management_service.go
+++ b/internal/provider/common/repository_management_service.go
@@ -1,0 +1,2617 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// RepositoryManagementService abstracts repository CRUD across NXRM API client
+// generations. Every method's request/response shape is expressed in terms of the V382
+// ("github.com/.../nexus-repo-api-client-go/v3") generated types -- the vocabulary the
+// existing internal/provider/model package's per-format FromApiModel/ToApiCreateModel/
+// ToApiUpdateModel methods are already written against. The V395 adapter bridges to/from
+// its own generated types internally so that callers (internal/provider/repository/format)
+// never need to know which generation is behind the interface.
+type RepositoryManagementService interface {
+	DeleteRepository(ctx context.Context, repositoryName string) (*http.Response, error)
+	ListRepositories(ctx context.Context) ([]sonatyperepoV382.RepositoryXO, *http.Response, error)
+	CreateAlpineGroupRepository(ctx context.Context, body sonatyperepoV382.AlpineGroupRepositoryApiRequest) (*http.Response, error)
+	GetAlpineGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineGroupApiRepository, *http.Response, error)
+	UpdateAlpineGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineGroupRepositoryApiRequest) (*http.Response, error)
+	CreateAlpineHostedRepository(ctx context.Context, body sonatyperepoV382.AlpineHostedRepositoryApiRequest) (*http.Response, error)
+	GetAlpineHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineHostedApiRepository, *http.Response, error)
+	UpdateAlpineHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineHostedRepositoryApiRequest) (*http.Response, error)
+	CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error)
+	GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *http.Response, error)
+	UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error)
+	CreateAnsiblegalaxyGroupRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyGroupRepositoryApiRequest) (*http.Response, error)
+	GetAnsiblegalaxyGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyGroupApiRepository, *http.Response, error)
+	UpdateAnsiblegalaxyGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyGroupRepositoryApiRequest) (*http.Response, error)
+	CreateAnsiblegalaxyHostedRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyHostedRepositoryApiRequest) (*http.Response, error)
+	GetAnsiblegalaxyHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyHostedApiRepository, *http.Response, error)
+	UpdateAnsiblegalaxyHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyHostedRepositoryApiRequest) (*http.Response, error)
+	CreateAnsiblegalaxyProxyRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyProxyRepositoryApiRequest) (*http.Response, error)
+	GetAnsiblegalaxyProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyProxyApiRepository, *http.Response, error)
+	UpdateAnsiblegalaxyProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyProxyRepositoryApiRequest) (*http.Response, error)
+	CreateAptHostedRepository(ctx context.Context, body sonatyperepoV382.AptHostedRepositoryApiRequest) (*http.Response, error)
+	GetAptHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AptHostedApiRepository, *http.Response, error)
+	UpdateAptHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AptHostedRepositoryApiRequest) (*http.Response, error)
+	CreateAptProxyRepository(ctx context.Context, body sonatyperepoV382.AptProxyRepositoryApiRequest) (*http.Response, error)
+	GetAptProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AptProxyApiRepository, *http.Response, error)
+	UpdateAptProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AptProxyRepositoryApiRequest) (*http.Response, error)
+	CreateCargoGroupRepository(ctx context.Context, body sonatyperepoV382.CargoGroupRepositoryApiRequest) (*http.Response, error)
+	GetCargoGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoGroupApiRepository, *http.Response, error)
+	UpdateCargoGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoGroupRepositoryApiRequest) (*http.Response, error)
+	CreateCargoHostedRepository(ctx context.Context, body sonatyperepoV382.CargoHostedRepositoryApiRequest) (*http.Response, error)
+	GetCargoHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateCargoHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoHostedRepositoryApiRequest) (*http.Response, error)
+	CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error)
+	GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *http.Response, error)
+	UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error)
+	CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error)
+	GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error)
+	CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error)
+	GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error)
+	CreateConanGroupRepository(ctx context.Context, body sonatyperepoV382.ConanGroupRepositoryApiRequest) (*http.Response, error)
+	GetConanGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error)
+	UpdateConanGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanGroupRepositoryApiRequest) (*http.Response, error)
+	CreateConanHostedRepository(ctx context.Context, body sonatyperepoV382.ConanHostedRepositoryApiRequest) (*http.Response, error)
+	GetConanHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateConanHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanHostedRepositoryApiRequest) (*http.Response, error)
+	CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error)
+	GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *http.Response, error)
+	UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error)
+	CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error)
+	GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error)
+	CreateDockerGroupRepository(ctx context.Context, body sonatyperepoV382.DockerGroupRepositoryApiRequest) (*http.Response, error)
+	GetDockerGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerGroupApiRepository, *http.Response, error)
+	UpdateDockerGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerGroupRepositoryApiRequest) (*http.Response, error)
+	CreateDockerHostedRepository(ctx context.Context, body sonatyperepoV382.DockerHostedRepositoryApiRequest) (*http.Response, error)
+	GetDockerHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerHostedApiRepository, *http.Response, error)
+	UpdateDockerHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerHostedRepositoryApiRequest) (*http.Response, error)
+	CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error)
+	GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *http.Response, error)
+	UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error)
+	CreateGitlfsHostedRepository(ctx context.Context, body sonatyperepoV382.GitLfsHostedRepositoryApiRequest) (*http.Response, error)
+	GetGitlfsHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateGitlfsHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GitLfsHostedRepositoryApiRequest) (*http.Response, error)
+	CreateGoGroupRepository(ctx context.Context, body sonatyperepoV382.GolangGroupRepositoryApiRequest) (*http.Response, error)
+	GetGoGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
+	UpdateGoGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangGroupRepositoryApiRequest) (*http.Response, error)
+	CreateGoHostedRepository(ctx context.Context, body sonatyperepoV382.GolangHostedRepositoryApiRequest) (*http.Response, error)
+	GetGoHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateGoHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangHostedRepositoryApiRequest) (*http.Response, error)
+	CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error)
+	GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error)
+	CreateHelmGroupRepository(ctx context.Context, body sonatyperepoV382.HelmGroupRepositoryApiRequest) (*http.Response, error)
+	GetHelmGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
+	UpdateHelmGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmGroupRepositoryApiRequest) (*http.Response, error)
+	CreateHelmHostedRepository(ctx context.Context, body sonatyperepoV382.HelmHostedRepositoryApiRequest) (*http.Response, error)
+	GetHelmHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateHelmHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmHostedRepositoryApiRequest) (*http.Response, error)
+	CreateHelmProxyRepository(ctx context.Context, body sonatyperepoV382.HelmProxyRepositoryApiRequest) (*http.Response, error)
+	GetHelmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateHelmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmProxyRepositoryApiRequest) (*http.Response, error)
+	CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error)
+	GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error)
+	CreateMavenGroupRepository(ctx context.Context, body sonatyperepoV382.MavenGroupRepositoryApiRequest) (*http.Response, error)
+	GetMavenGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
+	UpdateMavenGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenGroupRepositoryApiRequest) (*http.Response, error)
+	CreateMavenHostedRepository(ctx context.Context, body sonatyperepoV382.MavenHostedRepositoryApiRequest) (*http.Response, error)
+	GetMavenHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenHostedApiRepository, *http.Response, error)
+	UpdateMavenHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenHostedRepositoryApiRequest) (*http.Response, error)
+	CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error)
+	GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *http.Response, error)
+	UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error)
+	CreateNpmGroupRepository(ctx context.Context, body sonatyperepoV382.NpmGroupRepositoryApiRequest) (*http.Response, error)
+	GetNpmGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error)
+	UpdateNpmGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmGroupRepositoryApiRequest) (*http.Response, error)
+	CreateNpmHostedRepository(ctx context.Context, body sonatyperepoV382.NpmHostedRepositoryApiRequest) (*http.Response, error)
+	GetNpmHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateNpmHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmHostedRepositoryApiRequest) (*http.Response, error)
+	CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error)
+	GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *http.Response, error)
+	UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error)
+	CreateNugetGroupRepository(ctx context.Context, body sonatyperepoV382.NugetGroupRepositoryApiRequest) (*http.Response, error)
+	GetNugetGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
+	UpdateNugetGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetGroupRepositoryApiRequest) (*http.Response, error)
+	CreateNugetHostedRepository(ctx context.Context, body sonatyperepoV382.NugetHostedRepositoryApiRequest) (*http.Response, error)
+	GetNugetHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateNugetHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetHostedRepositoryApiRequest) (*http.Response, error)
+	CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error)
+	GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *http.Response, error)
+	UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error)
+	CreateP2ProxyRepository(ctx context.Context, body sonatyperepoV382.P2ProxyRepositoryApiRequest) (*http.Response, error)
+	GetP2ProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateP2ProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.P2ProxyRepositoryApiRequest) (*http.Response, error)
+	CreatePypiGroupRepository(ctx context.Context, body sonatyperepoV382.PypiGroupRepositoryApiRequest) (*http.Response, error)
+	GetPypiGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error)
+	UpdatePypiGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiGroupRepositoryApiRequest) (*http.Response, error)
+	CreatePypiHostedRepository(ctx context.Context, body sonatyperepoV382.PypiHostedRepositoryApiRequest) (*http.Response, error)
+	GetPypiHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdatePypiHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiHostedRepositoryApiRequest) (*http.Response, error)
+	CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error)
+	GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *http.Response, error)
+	UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error)
+	CreateRGroupRepository(ctx context.Context, body sonatyperepoV382.RGroupRepositoryApiRequest) (*http.Response, error)
+	GetRGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
+	UpdateRGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RGroupRepositoryApiRequest) (*http.Response, error)
+	CreateRHostedRepository(ctx context.Context, body sonatyperepoV382.RHostedRepositoryApiRequest) (*http.Response, error)
+	GetRHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateRHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RHostedRepositoryApiRequest) (*http.Response, error)
+	CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error)
+	GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error)
+	CreateRawGroupRepository(ctx context.Context, body sonatyperepoV382.RawGroupRepositoryApiRequest) (*http.Response, error)
+	GetRawGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawGroupApiRepository, *http.Response, error)
+	UpdateRawGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawGroupRepositoryApiRequest) (*http.Response, error)
+	CreateRawHostedRepository(ctx context.Context, body sonatyperepoV382.RawHostedRepositoryApiRequest) (*http.Response, error)
+	GetRawHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawHostedApiRepository, *http.Response, error)
+	UpdateRawHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawHostedRepositoryApiRequest) (*http.Response, error)
+	CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error)
+	GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *http.Response, error)
+	UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error)
+	CreateRubygemsGroupRepository(ctx context.Context, body sonatyperepoV382.RubyGemsGroupRepositoryApiRequest) (*http.Response, error)
+	GetRubygemsGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
+	UpdateRubygemsGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsGroupRepositoryApiRequest) (*http.Response, error)
+	CreateRubygemsHostedRepository(ctx context.Context, body sonatyperepoV382.RubyGemsHostedRepositoryApiRequest) (*http.Response, error)
+	GetRubygemsHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
+	UpdateRubygemsHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsHostedRepositoryApiRequest) (*http.Response, error)
+	CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error)
+	GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
+	UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error)
+	CreateSwiftGroupRepository(ctx context.Context, body sonatyperepoV382.SwiftGroupRepositoryApiRequest) (*http.Response, error)
+	GetSwiftGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SwiftGroupApiRepository, *http.Response, error)
+	UpdateSwiftGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.SwiftGroupRepositoryApiRequest) (*http.Response, error)
+	CreateSwiftProxyRepository(ctx context.Context, body sonatyperepoV382.SwiftProxyRepositoryApiRequest) (*http.Response, error)
+	GetSwiftProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SwiftProxyApiRepository, *http.Response, error)
+	UpdateSwiftProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.SwiftProxyRepositoryApiRequest) (*http.Response, error)
+	CreateTerraformGroupRepository(ctx context.Context, body sonatyperepoV382.TerraformGroupRepositoryApiRequest) (*http.Response, error)
+	GetTerraformGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformGroupApiRepository, *http.Response, error)
+	UpdateTerraformGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformGroupRepositoryApiRequest) (*http.Response, error)
+	CreateTerraformHostedRepository(ctx context.Context, body sonatyperepoV382.TerraformHostedRepositoryApiRequest) (*http.Response, error)
+	GetTerraformHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformHostedRepositoryApiRequest, *http.Response, error)
+	UpdateTerraformHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformHostedRepositoryApiRequest) (*http.Response, error)
+	CreateTerraformProxyRepository(ctx context.Context, body sonatyperepoV382.TerraformProxyRepositoryApiRequest) (*http.Response, error)
+	GetTerraformProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformProxyApiRepository, *http.Response, error)
+	UpdateTerraformProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformProxyRepositoryApiRequest) (*http.Response, error)
+	CreateYumGroupRepository(ctx context.Context, body sonatyperepoV382.YumGroupRepositoryApiRequest) (*http.Response, error)
+	GetYumGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumGroupApiRepository, *http.Response, error)
+	UpdateYumGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumGroupRepositoryApiRequest) (*http.Response, error)
+	CreateYumHostedRepository(ctx context.Context, body sonatyperepoV382.YumHostedRepositoryApiRequest) (*http.Response, error)
+	GetYumHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumHostedApiRepository, *http.Response, error)
+	UpdateYumHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumHostedRepositoryApiRequest) (*http.Response, error)
+	CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error)
+	GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *http.Response, error)
+	UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error)
+}
+
+// repositoryManagementServiceV382 implements RepositoryManagementService against NXRM API
+// client V382 (targets NXRM < 3.94.0). Every method is a direct, unmodified delegation to
+// the generated client -- V382 types are this interface's native vocabulary.
+type repositoryManagementServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *repositoryManagementServiceV382) DeleteRepository(ctx context.Context, repositoryName string) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.DeleteRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) ListRepositories(ctx context.Context) ([]sonatyperepoV382.RepositoryXO, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAllRepositories(ctx).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateAlpineGroupRepository(ctx context.Context, body sonatyperepoV382.AlpineGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateAlpineGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetAlpineGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineGroupApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAlpineGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateAlpineGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateAlpineGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateAlpineHostedRepository(ctx context.Context, body sonatyperepoV382.AlpineHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateAlpineHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetAlpineHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineHostedApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAlpineHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateAlpineHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateAlpineHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateAlpineProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAlpineProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateAlpineProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateAnsiblegalaxyGroupRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateAnsiblegalaxyGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetAnsiblegalaxyGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyGroupApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAnsiblegalaxyGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateAnsiblegalaxyGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateAnsiblegalaxyGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateAnsiblegalaxyHostedRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateAnsiblegalaxyHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetAnsiblegalaxyHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyHostedApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAnsiblegalaxyHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateAnsiblegalaxyHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateAnsiblegalaxyHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateAnsiblegalaxyProxyRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateAnsiblegalaxyProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetAnsiblegalaxyProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAnsiblegalaxyProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateAnsiblegalaxyProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateAnsiblegalaxyProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateAptHostedRepository(ctx context.Context, body sonatyperepoV382.AptHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateAptHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetAptHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AptHostedApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAptHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateAptHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AptHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateAptHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateAptProxyRepository(ctx context.Context, body sonatyperepoV382.AptProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateAptProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetAptProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AptProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetAptProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateAptProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AptProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateAptProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateCargoGroupRepository(ctx context.Context, body sonatyperepoV382.CargoGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateCargoGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetCargoGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoGroupApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetCargoGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateCargoGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateCargoGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateCargoHostedRepository(ctx context.Context, body sonatyperepoV382.CargoHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateCargoHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetCargoHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetCargoHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateCargoHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateCargoHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateCargoProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetCargoProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateCargoProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateCocoapodsProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetCocoapodsProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateCocoapodsProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateComposerProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetComposerProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateComposerProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateConanGroupRepository(ctx context.Context, body sonatyperepoV382.ConanGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateConanGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetConanGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetConanGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateConanGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateConanGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateConanHostedRepository(ctx context.Context, body sonatyperepoV382.ConanHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateConanHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetConanHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetConanHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateConanHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateConanHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateConanProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetConanProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateConanProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateCondaProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetCondaProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateCondaProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateDockerGroupRepository(ctx context.Context, body sonatyperepoV382.DockerGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateDockerGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetDockerGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerGroupApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetDockerGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateDockerGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateDockerGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateDockerHostedRepository(ctx context.Context, body sonatyperepoV382.DockerHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateDockerHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetDockerHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerHostedApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetDockerHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateDockerHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateDockerHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateDockerProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetDockerProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateDockerProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateGitlfsHostedRepository(ctx context.Context, body sonatyperepoV382.GitLfsHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateGitlfsHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetGitlfsHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetGitlfsHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateGitlfsHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GitLfsHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateGitlfsHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateGoGroupRepository(ctx context.Context, body sonatyperepoV382.GolangGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateGoGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetGoGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetGoGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateGoGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateGoGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateGoHostedRepository(ctx context.Context, body sonatyperepoV382.GolangHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateGoHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetGoHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetGoHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateGoHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateGoHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateGoProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetGoProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateGoProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateHelmGroupRepository(ctx context.Context, body sonatyperepoV382.HelmGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateHelmGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetHelmGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetHelmGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateHelmGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateHelmGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateHelmHostedRepository(ctx context.Context, body sonatyperepoV382.HelmHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateHelmHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetHelmHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetHelmHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateHelmHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateHelmHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateHelmProxyRepository(ctx context.Context, body sonatyperepoV382.HelmProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateHelmProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetHelmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetHelmProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateHelmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateHelmProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateHuggingfaceProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetHuggingfaceProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateHuggingfaceProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateMavenGroupRepository(ctx context.Context, body sonatyperepoV382.MavenGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateMavenGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetMavenGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetMavenGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateMavenGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateMavenGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateMavenHostedRepository(ctx context.Context, body sonatyperepoV382.MavenHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateMavenHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetMavenHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenHostedApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetMavenHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateMavenHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateMavenHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateMavenProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetMavenProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateMavenProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateNpmGroupRepository(ctx context.Context, body sonatyperepoV382.NpmGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateNpmGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetNpmGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetNpmGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateNpmGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateNpmGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateNpmHostedRepository(ctx context.Context, body sonatyperepoV382.NpmHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateNpmHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetNpmHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetNpmHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateNpmHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateNpmHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateNpmProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetNpmProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateNpmProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateNugetGroupRepository(ctx context.Context, body sonatyperepoV382.NugetGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateNugetGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetNugetGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetNugetGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateNugetGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateNugetGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateNugetHostedRepository(ctx context.Context, body sonatyperepoV382.NugetHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateNugetHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetNugetHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetNugetHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateNugetHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateNugetHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateNugetProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetNugetProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateNugetProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateP2ProxyRepository(ctx context.Context, body sonatyperepoV382.P2ProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateP2ProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetP2ProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetP2ProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateP2ProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.P2ProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateP2ProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreatePypiGroupRepository(ctx context.Context, body sonatyperepoV382.PypiGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreatePypiGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetPypiGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetPypiGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdatePypiGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdatePypiGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreatePypiHostedRepository(ctx context.Context, body sonatyperepoV382.PypiHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreatePypiHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetPypiHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetPypiHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdatePypiHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdatePypiHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreatePypiProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetPypiProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdatePypiProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRGroupRepository(ctx context.Context, body sonatyperepoV382.RGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRHostedRepository(ctx context.Context, body sonatyperepoV382.RHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRawGroupRepository(ctx context.Context, body sonatyperepoV382.RawGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRawGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRawGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawGroupApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRawGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRawGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRawGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRawHostedRepository(ctx context.Context, body sonatyperepoV382.RawHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRawHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRawHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawHostedApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRawHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRawHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRawHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRawProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRawProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRawProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRubygemsGroupRepository(ctx context.Context, body sonatyperepoV382.RubyGemsGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRubygemsGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRubygemsGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRubygemsGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRubygemsGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRubygemsGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRubygemsHostedRepository(ctx context.Context, body sonatyperepoV382.RubyGemsHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRubygemsHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRubygemsHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRubygemsHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRubygemsHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRubygemsHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateRubygemsProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetRubygemsProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateRubygemsProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateSwiftGroupRepository(ctx context.Context, body sonatyperepoV382.SwiftGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateSwiftGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetSwiftGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SwiftGroupApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetSwiftGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateSwiftGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.SwiftGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateSwiftGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateSwiftProxyRepository(ctx context.Context, body sonatyperepoV382.SwiftProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateSwiftProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetSwiftProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SwiftProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetSwiftProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateSwiftProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.SwiftProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateSwiftProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateTerraformGroupRepository(ctx context.Context, body sonatyperepoV382.TerraformGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateTerraformGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetTerraformGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformGroupApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetTerraformGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateTerraformGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateTerraformGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateTerraformHostedRepository(ctx context.Context, body sonatyperepoV382.TerraformHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateTerraformHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetTerraformHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformHostedRepositoryApiRequest, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetTerraformHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateTerraformHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateTerraformHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateTerraformProxyRepository(ctx context.Context, body sonatyperepoV382.TerraformProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateTerraformProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetTerraformProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetTerraformProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateTerraformProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateTerraformProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateYumGroupRepository(ctx context.Context, body sonatyperepoV382.YumGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateYumGroupRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetYumGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumGroupApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetYumGroupRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateYumGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumGroupRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateYumGroupRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateYumHostedRepository(ctx context.Context, body sonatyperepoV382.YumHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateYumHostedRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetYumHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumHostedApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetYumHostedRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateYumHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumHostedRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateYumHostedRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.CreateYumProxyRepository(ctx).Body(body).Execute()
+}
+
+func (s *repositoryManagementServiceV382) GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *http.Response, error) {
+	return s.client.RepositoryManagementAPI.GetYumProxyRepository(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV382) UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.UpdateYumProxyRepository(ctx, repositoryName).Body(body).Execute()
+}
+
+// repositoryManagementServiceV395 implements RepositoryManagementService against NXRM API
+// client V395 (targets NXRM 3.94.0+). Requests/responses are bridged to/from V382 shapes via
+// JSON, since the internal/provider/model package's mapping methods are written in terms of
+// V382 types. Known field renames that survive the JSON bridge incorrectly (because the JSON
+// key itself changed) are patched explicitly:
+//   - RoutingRule (V382) -> RoutingRuleName (V395), on the write side of proxy formats.
+//   - npm/pypi proxy "RemoveQuarantined" (PCCS) has no equivalent field on the V395 repository
+//     struct at all (confirmed removed, not renamed) -- reads of this flag against NXRM 3.94+
+//     always come back false, and writes of it are silently dropped. Restoring this behavior
+//     requires integrating a separate Capability-API-based PCCS toggle, which is out of scope
+//     for this struct-mapping bridge; tracked as a follow-up.
+type repositoryManagementServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *repositoryManagementServiceV395) DeleteRepository(ctx context.Context, repositoryName string) (*http.Response, error) {
+	return s.client.RepositoryManagementAPI.DeleteRepositories(ctx, repositoryName).Execute()
+}
+
+func (s *repositoryManagementServiceV395) ListRepositories(ctx context.Context) ([]sonatyperepoV382.RepositoryXO, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAllRepositories(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result []sonatyperepoV382.RepositoryXO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) CreateAlpineGroupRepository(ctx context.Context, body sonatyperepoV382.AlpineGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AlpineGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateAlpineGroupRepository(ctx).AlpineGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetAlpineGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineGroupApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAlpineGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AlpineGroupApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateAlpineGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AlpineGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateAlpineGroupRepository(ctx, repositoryName).AlpineGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateAlpineHostedRepository(ctx context.Context, body sonatyperepoV382.AlpineHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AlpineHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateAlpineHostedRepository(ctx).AlpineHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetAlpineHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineHostedApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAlpineHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AlpineHostedApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateAlpineHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AlpineHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateAlpineHostedRepository(ctx, repositoryName).AlpineHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateAlpineProxyRepository(ctx context.Context, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AlpineProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateAlpineProxyRepository(ctx).AlpineProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetAlpineProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AlpineProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAlpineProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AlpineProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateAlpineProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AlpineProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AlpineProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateAlpineProxyRepository(ctx, repositoryName).AlpineProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateAnsiblegalaxyGroupRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AnsibleGalaxyGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateAnsiblegalaxyGroupRepository(ctx).AnsibleGalaxyGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetAnsiblegalaxyGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyGroupApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAnsiblegalaxyGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AnsibleGalaxyGroupApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateAnsiblegalaxyGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AnsibleGalaxyGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateAnsiblegalaxyGroupRepository(ctx, repositoryName).AnsibleGalaxyGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateAnsiblegalaxyHostedRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AnsibleGalaxyHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateAnsiblegalaxyHostedRepository(ctx).AnsibleGalaxyHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetAnsiblegalaxyHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyHostedApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAnsiblegalaxyHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AnsibleGalaxyHostedApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateAnsiblegalaxyHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AnsibleGalaxyHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateAnsiblegalaxyHostedRepository(ctx, repositoryName).AnsibleGalaxyHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateAnsiblegalaxyProxyRepository(ctx context.Context, body sonatyperepoV382.AnsibleGalaxyProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AnsibleGalaxyProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateAnsiblegalaxyProxyRepository(ctx).AnsibleGalaxyProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetAnsiblegalaxyProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AnsibleGalaxyProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAnsiblegalaxyProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AnsibleGalaxyProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateAnsiblegalaxyProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AnsibleGalaxyProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AnsibleGalaxyProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateAnsiblegalaxyProxyRepository(ctx, repositoryName).AnsibleGalaxyProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateAptHostedRepository(ctx context.Context, body sonatyperepoV382.AptHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AptHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateAptHostedRepository(ctx).AptHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetAptHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AptHostedApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAptHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AptHostedApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateAptHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AptHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AptHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateAptHostedRepository(ctx, repositoryName).AptHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateAptProxyRepository(ctx context.Context, body sonatyperepoV382.AptProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AptProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateAptProxyRepository(ctx).AptProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetAptProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.AptProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetAptProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.AptProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateAptProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.AptProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.AptProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateAptProxyRepository(ctx, repositoryName).AptProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateCargoGroupRepository(ctx context.Context, body sonatyperepoV382.CargoGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CargoGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateCargoGroupRepository(ctx).CargoGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetCargoGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoGroupApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetCargoGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.CargoGroupApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateCargoGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CargoGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateCargoGroupRepository(ctx, repositoryName).CargoGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateCargoHostedRepository(ctx context.Context, body sonatyperepoV382.CargoHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CargoHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateCargoHostedRepository(ctx).CargoHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetCargoHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetCargoHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateCargoHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CargoHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateCargoHostedRepository(ctx, repositoryName).CargoHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CargoProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateCargoProxyRepository(ctx).CargoProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetCargoProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.CargoProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CargoProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateCargoProxyRepository(ctx, repositoryName).CargoProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CocoapodsProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateCocoapodsProxyRepository(ctx).CocoapodsProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetCocoapodsProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CocoapodsProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateCocoapodsProxyRepository(ctx, repositoryName).CocoapodsProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ComposerProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateComposerProxyRepository(ctx).ComposerProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetComposerProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ComposerProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateComposerProxyRepository(ctx, repositoryName).ComposerProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateConanGroupRepository(ctx context.Context, body sonatyperepoV382.ConanGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ConanGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateConanGroupRepository(ctx).ConanGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetConanGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetConanGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupDeployRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateConanGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ConanGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateConanGroupRepository(ctx, repositoryName).ConanGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateConanHostedRepository(ctx context.Context, body sonatyperepoV382.ConanHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ConanHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateConanHostedRepository(ctx).ConanHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetConanHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetConanHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateConanHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ConanHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateConanHostedRepository(ctx, repositoryName).ConanHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ConanProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateConanProxyRepository(ctx).ConanProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetConanProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.ConanProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.ConanProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateConanProxyRepository(ctx, repositoryName).ConanProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CondaProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateCondaProxyRepository(ctx).CondaProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetCondaProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.CondaProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateCondaProxyRepository(ctx, repositoryName).CondaProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateDockerGroupRepository(ctx context.Context, body sonatyperepoV382.DockerGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.DockerGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateDockerGroupRepository(ctx).DockerGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetDockerGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerGroupApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetDockerGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.DockerGroupApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateDockerGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.DockerGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateDockerGroupRepository(ctx, repositoryName).DockerGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateDockerHostedRepository(ctx context.Context, body sonatyperepoV382.DockerHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.DockerHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateDockerHostedRepository(ctx).DockerHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetDockerHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerHostedApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetDockerHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.DockerHostedApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateDockerHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.DockerHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateDockerHostedRepository(ctx, repositoryName).DockerHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateDockerProxyRepository(ctx context.Context, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.DockerProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateDockerProxyRepository(ctx).DockerProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetDockerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetDockerProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.DockerProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateDockerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.DockerProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateDockerProxyRepository(ctx, repositoryName).DockerProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateGitlfsHostedRepository(ctx context.Context, body sonatyperepoV382.GitLfsHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GitLfsHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateGitlfsHostedRepository(ctx).GitLfsHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetGitlfsHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetGitlfsHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateGitlfsHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GitLfsHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GitLfsHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateGitlfsHostedRepository(ctx, repositoryName).GitLfsHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateGoGroupRepository(ctx context.Context, body sonatyperepoV382.GolangGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GolangGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateGoGroupRepository(ctx).GolangGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetGoGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetGoGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateGoGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GolangGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateGoGroupRepository(ctx, repositoryName).GolangGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateGoHostedRepository(ctx context.Context, body sonatyperepoV382.GolangHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GolangHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateGoHostedRepository(ctx).GolangHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetGoHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetGoHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateGoHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GolangHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateGoHostedRepository(ctx, repositoryName).GolangHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateGoProxyRepository(ctx context.Context, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GolangProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateGoProxyRepository(ctx).GolangProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetGoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetGoProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateGoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.GolangProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.GolangProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateGoProxyRepository(ctx, repositoryName).GolangProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateHelmGroupRepository(ctx context.Context, body sonatyperepoV382.HelmGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.HelmGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateHelmGroupRepository(ctx).HelmGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetHelmGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetHelmGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateHelmGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.HelmGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateHelmGroupRepository(ctx, repositoryName).HelmGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateHelmHostedRepository(ctx context.Context, body sonatyperepoV382.HelmHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.HelmHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateHelmHostedRepository(ctx).HelmHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetHelmHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetHelmHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateHelmHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.HelmHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateHelmHostedRepository(ctx, repositoryName).HelmHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateHelmProxyRepository(ctx context.Context, body sonatyperepoV382.HelmProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.HelmProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateHelmProxyRepository(ctx).HelmProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetHelmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetHelmProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateHelmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HelmProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.HelmProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateHelmProxyRepository(ctx, repositoryName).HelmProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateHuggingfaceProxyRepository(ctx context.Context, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.HuggingFaceProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateHuggingfaceProxyRepository(ctx).HuggingFaceProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetHuggingfaceProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetHuggingfaceProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateHuggingfaceProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.HuggingFaceProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.HuggingFaceProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateHuggingfaceProxyRepository(ctx, repositoryName).HuggingFaceProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateMavenGroupRepository(ctx context.Context, body sonatyperepoV382.MavenGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.MavenGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateMavenGroupRepository(ctx).MavenGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetMavenGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetMavenGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateMavenGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.MavenGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateMavenGroupRepository(ctx, repositoryName).MavenGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateMavenHostedRepository(ctx context.Context, body sonatyperepoV382.MavenHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.MavenHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateMavenHostedRepository(ctx).MavenHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetMavenHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenHostedApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetMavenHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.MavenHostedApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateMavenHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.MavenHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateMavenHostedRepository(ctx, repositoryName).MavenHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.MavenProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateMavenProxyRepository(ctx).MavenProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetMavenProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.MavenProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.MavenProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateMavenProxyRepository(ctx, repositoryName).MavenProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateNpmGroupRepository(ctx context.Context, body sonatyperepoV382.NpmGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NpmGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateNpmGroupRepository(ctx).NpmGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetNpmGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetNpmGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupDeployRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateNpmGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NpmGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateNpmGroupRepository(ctx, repositoryName).NpmGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateNpmHostedRepository(ctx context.Context, body sonatyperepoV382.NpmHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NpmHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateNpmHostedRepository(ctx).NpmHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetNpmHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetNpmHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateNpmHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NpmHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateNpmHostedRepository(ctx, repositoryName).NpmHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateNpmProxyRepository(ctx context.Context, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NpmProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateNpmProxyRepository(ctx).NpmProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetNpmProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NpmProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetNpmProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.NpmProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateNpmProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NpmProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateNpmProxyRepository(ctx, repositoryName).NpmProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateNugetGroupRepository(ctx context.Context, body sonatyperepoV382.NugetGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NugetGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateNugetGroupRepository(ctx).NugetGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetNugetGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetNugetGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateNugetGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NugetGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateNugetGroupRepository(ctx, repositoryName).NugetGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateNugetHostedRepository(ctx context.Context, body sonatyperepoV382.NugetHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NugetHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateNugetHostedRepository(ctx).NugetHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetNugetHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetNugetHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateNugetHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NugetHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateNugetHostedRepository(ctx, repositoryName).NugetHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NugetProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateNugetProxyRepository(ctx).NugetProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetNugetProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.NugetProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.NugetProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateNugetProxyRepository(ctx, repositoryName).NugetProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateP2ProxyRepository(ctx context.Context, body sonatyperepoV382.P2ProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.P2ProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateP2ProxyRepository(ctx).P2ProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetP2ProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetP2ProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateP2ProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.P2ProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.P2ProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateP2ProxyRepository(ctx, repositoryName).P2ProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreatePypiGroupRepository(ctx context.Context, body sonatyperepoV382.PypiGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.PypiGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreatePypiGroupRepository(ctx).PypiGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetPypiGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetPypiGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupDeployRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdatePypiGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.PypiGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdatePypiGroupRepository(ctx, repositoryName).PypiGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreatePypiHostedRepository(ctx context.Context, body sonatyperepoV382.PypiHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.PypiHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreatePypiHostedRepository(ctx).PypiHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetPypiHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetPypiHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdatePypiHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.PypiHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdatePypiHostedRepository(ctx, repositoryName).PypiHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreatePypiProxyRepository(ctx context.Context, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.PypiProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreatePypiProxyRepository(ctx).PypiProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetPypiProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.PyPiProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetPypiProxyRepository(ctx, repositoryName).Execute()
+	var result sonatyperepoV382.PyPiProxyApiRepository
+	if err := bridgeFromResponse(apiV395, httpResponse, err, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdatePypiProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.PypiProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.PypiProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdatePypiProxyRepository(ctx, repositoryName).PypiProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRGroupRepository(ctx context.Context, body sonatyperepoV382.RGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateRGroupRepository(ctx).RGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateRGroupRepository(ctx, repositoryName).RGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRHostedRepository(ctx context.Context, body sonatyperepoV382.RHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateRHostedRepository(ctx).RHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateRHostedRepository(ctx, repositoryName).RHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRProxyRepository(ctx context.Context, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateRProxyRepository(ctx).RProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateRProxyRepository(ctx, repositoryName).RProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRawGroupRepository(ctx context.Context, body sonatyperepoV382.RawGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RawGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateRawGroupRepository(ctx).RawGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRawGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawGroupApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRawGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.RawGroupApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRawGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RawGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateRawGroupRepository(ctx, repositoryName).RawGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRawHostedRepository(ctx context.Context, body sonatyperepoV382.RawHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RawHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateRawHostedRepository(ctx).RawHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRawHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawHostedApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRawHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.RawHostedApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRawHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RawHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateRawHostedRepository(ctx, repositoryName).RawHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RawProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateRawProxyRepository(ctx).RawProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRawProxyRepository(ctx, repositoryName).Execute()
+	var result sonatyperepoV382.RawProxyApiRepository
+	if err := bridgeFromResponse(apiV395, httpResponse, err, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RawProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateRawProxyRepository(ctx, repositoryName).RawProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRubygemsGroupRepository(ctx context.Context, body sonatyperepoV382.RubyGemsGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RubyGemsGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateRubygemsGroupRepository(ctx).RubyGemsGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRubygemsGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRubygemsGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiGroupRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRubygemsGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RubyGemsGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateRubygemsGroupRepository(ctx, repositoryName).RubyGemsGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRubygemsHostedRepository(ctx context.Context, body sonatyperepoV382.RubyGemsHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RubyGemsHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateRubygemsHostedRepository(ctx).RubyGemsHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRubygemsHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRubygemsHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiHostedRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRubygemsHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RubyGemsHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateRubygemsHostedRepository(ctx, repositoryName).RubyGemsHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RubyGemsProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateRubygemsProxyRepository(ctx).RubyGemsProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRubygemsProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SimpleApiProxyRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RubyGemsProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateRubygemsProxyRepository(ctx, repositoryName).RubyGemsProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateSwiftGroupRepository(ctx context.Context, body sonatyperepoV382.SwiftGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.SwiftGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateSwiftGroupRepository(ctx).SwiftGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetSwiftGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SwiftGroupApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetSwiftGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SwiftGroupApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateSwiftGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.SwiftGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.SwiftGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateSwiftGroupRepository(ctx, repositoryName).SwiftGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateSwiftProxyRepository(ctx context.Context, body sonatyperepoV382.SwiftProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.SwiftProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateSwiftProxyRepository(ctx).SwiftProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetSwiftProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SwiftProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetSwiftProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SwiftProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateSwiftProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.SwiftProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.SwiftProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateSwiftProxyRepository(ctx, repositoryName).SwiftProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateTerraformGroupRepository(ctx context.Context, body sonatyperepoV382.TerraformGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.TerraformGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateTerraformGroupRepository(ctx).TerraformGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetTerraformGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformGroupApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetTerraformGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.TerraformGroupApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateTerraformGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.TerraformGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateTerraformGroupRepository(ctx, repositoryName).TerraformGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateTerraformHostedRepository(ctx context.Context, body sonatyperepoV382.TerraformHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.TerraformHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateTerraformHostedRepository(ctx).TerraformHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetTerraformHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformHostedRepositoryApiRequest, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetTerraformHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.TerraformHostedRepositoryApiRequest
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateTerraformHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.TerraformHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateTerraformHostedRepository(ctx, repositoryName).TerraformHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateTerraformProxyRepository(ctx context.Context, body sonatyperepoV382.TerraformProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.TerraformProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateTerraformProxyRepository(ctx).TerraformProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetTerraformProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.TerraformProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetTerraformProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.TerraformProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateTerraformProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.TerraformProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.TerraformProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateTerraformProxyRepository(ctx, repositoryName).TerraformProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateYumGroupRepository(ctx context.Context, body sonatyperepoV382.YumGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.YumGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateYumGroupRepository(ctx).YumGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetYumGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumGroupApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetYumGroupRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.YumGroupApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateYumGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumGroupRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.YumGroupRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateYumGroupRepository(ctx, repositoryName).YumGroupRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateYumHostedRepository(ctx context.Context, body sonatyperepoV382.YumHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.YumHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.CreateYumHostedRepository(ctx).YumHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetYumHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumHostedApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetYumHostedRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.YumHostedApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateYumHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumHostedRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.YumHostedRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RepositoryManagementAPI.UpdateYumHostedRepository(ctx, repositoryName).YumHostedRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.YumProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.CreateYumProxyRepository(ctx).YumProxyRepositoryApiRequest(v395Body).Execute()
+}
+
+func (s *repositoryManagementServiceV395) GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetYumProxyRepository(ctx, repositoryName).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.YumProxyApiRepository
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *repositoryManagementServiceV395) UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.YumProxyRepositoryApiRequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	v395Body.RoutingRuleName = body.RoutingRule
+	return s.client.RepositoryManagementAPI.UpdateYumProxyRepository(ctx, repositoryName).YumProxyRepositoryApiRequest(v395Body).Execute()
+}

--- a/internal/provider/common/resource.go
+++ b/internal/provider/common/resource.go
@@ -42,6 +42,7 @@ type BaseResource struct {
 	NxrmVersion  SystemVersion
 	NxrmWritable bool
 	NodeCount    int32
+	Services     Services
 }
 
 // UpgradeState implements resource.ResourceWithUpgradeState.
@@ -106,6 +107,7 @@ func (r *BaseResource) Configure(_ context.Context, req resource.ConfigureReques
 	r.NxrmVersion = config.NxrmVersion
 	r.NxrmWritable = config.NxrmWritable
 	r.NodeCount = config.NodeCount
+	r.Services = config.Services
 }
 
 // AuthContext returns a new context with authentication set up for API calls

--- a/internal/provider/common/role_service.go
+++ b/internal/provider/common/role_service.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// RoleService abstracts the Security Management Roles API across NXRM API client generations.
+// Every method's request/response shape is expressed in terms of the V382 generated types --
+// the vocabulary the existing internal/provider/model package's mapping methods are already
+// written against.
+type RoleService interface {
+	CreateRole(ctx context.Context, body sonatyperepoV382.RoleXORequest) (*sonatyperepoV382.RoleXOResponse, *http.Response, error)
+	GetRole(ctx context.Context, id string) (*sonatyperepoV382.RoleXOResponse, *http.Response, error)
+	UpdateRole(ctx context.Context, id string, body sonatyperepoV382.RoleXORequest) (*http.Response, error)
+	DeleteRole(ctx context.Context, id string) (*http.Response, error)
+	GetRoles(ctx context.Context) ([]sonatyperepoV382.RoleXOResponse, *http.Response, error)
+}
+
+// roleServiceV382 implements RoleService against NXRM API client V382 (targets NXRM < 3.94.0).
+type roleServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *roleServiceV382) CreateRole(ctx context.Context, body sonatyperepoV382.RoleXORequest) (*sonatyperepoV382.RoleXOResponse, *http.Response, error) {
+	return s.client.SecurityManagementRolesAPI.Create(ctx).Body(body).Execute()
+}
+
+func (s *roleServiceV382) GetRole(ctx context.Context, id string) (*sonatyperepoV382.RoleXOResponse, *http.Response, error) {
+	return s.client.SecurityManagementRolesAPI.GetRole(ctx, id).Execute()
+}
+
+func (s *roleServiceV382) UpdateRole(ctx context.Context, id string, body sonatyperepoV382.RoleXORequest) (*http.Response, error) {
+	return s.client.SecurityManagementRolesAPI.Update(ctx, id).Body(body).Execute()
+}
+
+func (s *roleServiceV382) DeleteRole(ctx context.Context, id string) (*http.Response, error) {
+	return s.client.SecurityManagementRolesAPI.Delete(ctx, id).Execute()
+}
+
+func (s *roleServiceV382) GetRoles(ctx context.Context) ([]sonatyperepoV382.RoleXOResponse, *http.Response, error) {
+	return s.client.SecurityManagementRolesAPI.GetRoles(ctx).Execute()
+}
+
+// roleServiceV395 implements RoleService against NXRM API client V395 (targets NXRM 3.94.0+).
+// Requests/responses are bridged to/from V382 shapes via JSON, since the internal/provider/model
+// package's mapping methods are written in terms of V382 types.
+//
+// Field differences requiring explicit patching:
+//   - RoleXORequest.Id and Name changed from *string (V382) to string (V395). jsonBridge handles
+//     this transparently for reads (V395->V382). For writes (V382->V395), we bridge and then
+//     manually populate non-nil required fields from the V382 struct's optional fields.
+type roleServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *roleServiceV395) CreateRole(ctx context.Context, body sonatyperepoV382.RoleXORequest) (*sonatyperepoV382.RoleXOResponse, *http.Response, error) {
+	var v395Body sonatyperepoV395.RoleXORequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, nil, err
+	}
+	// Patch required fields: Id and Name changed from *string (V382) to string (V395)
+	if body.Id != nil {
+		v395Body.Id = *body.Id
+	}
+	if body.Name != nil {
+		v395Body.Name = *body.Name
+	}
+
+	apiV395, httpResponse, err := s.client.SecurityManagementRolesAPI.CreateSecurityRoles(ctx).RoleXORequest(v395Body).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.RoleXOResponse
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *roleServiceV395) GetRole(ctx context.Context, id string) (*sonatyperepoV382.RoleXOResponse, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.SecurityManagementRolesAPI.GetSecurityRoles(ctx, id).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.RoleXOResponse
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *roleServiceV395) UpdateRole(ctx context.Context, id string, body sonatyperepoV382.RoleXORequest) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RoleXORequest
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	// Patch required fields: Id and Name changed from *string (V382) to string (V395)
+	if body.Id != nil {
+		v395Body.Id = *body.Id
+	}
+	if body.Name != nil {
+		v395Body.Name = *body.Name
+	}
+
+	return s.client.SecurityManagementRolesAPI.UpdateSecurityRoles(ctx, id).RoleXORequest(v395Body).Execute()
+}
+
+func (s *roleServiceV395) DeleteRole(ctx context.Context, id string) (*http.Response, error) {
+	return s.client.SecurityManagementRolesAPI.DeleteSecurityRoles(ctx, id).Execute()
+}
+
+func (s *roleServiceV395) GetRoles(ctx context.Context) ([]sonatyperepoV382.RoleXOResponse, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.SecurityManagementRolesAPI.ListSecurityRoles(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result []sonatyperepoV382.RoleXOResponse
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return result, httpResponse, nil
+}

--- a/internal/provider/common/routing_rule_service.go
+++ b/internal/provider/common/routing_rule_service.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// RoutingRuleService abstracts routing rule CRUD across NXRM API client generations.
+// Every method's request/response shape is expressed in terms of the V382 generated types,
+// which the existing model-mapping layer already consumes.
+type RoutingRuleService interface {
+	CreateRoutingRule(ctx context.Context, body sonatyperepoV382.RoutingRuleXO) (*http.Response, error)
+	GetRoutingRule(ctx context.Context, name string) (*sonatyperepoV382.RoutingRuleXO, *http.Response, error)
+	UpdateRoutingRule(ctx context.Context, name string, body sonatyperepoV382.RoutingRuleXO) (*http.Response, error)
+	DeleteRoutingRule(ctx context.Context, name string) (*http.Response, error)
+	GetRoutingRules(ctx context.Context) ([]sonatyperepoV382.RoutingRuleXO, *http.Response, error)
+}
+
+// routingRuleServiceV382 implements RoutingRuleService against NXRM API client V382 (targets NXRM < 3.94.0).
+type routingRuleServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *routingRuleServiceV382) CreateRoutingRule(ctx context.Context, body sonatyperepoV382.RoutingRuleXO) (*http.Response, error) {
+	return s.client.RoutingRulesAPI.CreateRoutingRule(ctx).Body(body).Execute()
+}
+
+func (s *routingRuleServiceV382) GetRoutingRule(ctx context.Context, name string) (*sonatyperepoV382.RoutingRuleXO, *http.Response, error) {
+	return s.client.RoutingRulesAPI.GetRoutingRule(ctx, name).Execute()
+}
+
+func (s *routingRuleServiceV382) UpdateRoutingRule(ctx context.Context, name string, body sonatyperepoV382.RoutingRuleXO) (*http.Response, error) {
+	return s.client.RoutingRulesAPI.UpdateRoutingRule(ctx, name).Body(body).Execute()
+}
+
+func (s *routingRuleServiceV382) DeleteRoutingRule(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.RoutingRulesAPI.DeleteRoutingRule(ctx, name).Execute()
+}
+
+func (s *routingRuleServiceV382) GetRoutingRules(ctx context.Context) ([]sonatyperepoV382.RoutingRuleXO, *http.Response, error) {
+	return s.client.RoutingRulesAPI.GetRoutingRules(ctx).Execute()
+}
+
+// routingRuleServiceV395 implements RoutingRuleService against NXRM API client V395 (targets NXRM 3.94.0+).
+// V395 uses pluralized method names and different builder method for body, requiring careful bridging.
+type routingRuleServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *routingRuleServiceV395) CreateRoutingRule(ctx context.Context, body sonatyperepoV382.RoutingRuleXO) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RoutingRuleXO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RoutingRulesAPI.CreateRoutingRules(ctx).RoutingRuleXO(v395Body).Execute()
+}
+
+func (s *routingRuleServiceV395) GetRoutingRule(ctx context.Context, name string) (*sonatyperepoV382.RoutingRuleXO, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RoutingRulesAPI.GetRoutingRules(ctx, name).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.RoutingRuleXO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *routingRuleServiceV395) UpdateRoutingRule(ctx context.Context, name string, body sonatyperepoV382.RoutingRuleXO) (*http.Response, error) {
+	var v395Body sonatyperepoV395.RoutingRuleXO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.RoutingRulesAPI.UpdateRoutingRules(ctx, name).RoutingRuleXO(v395Body).Execute()
+}
+
+func (s *routingRuleServiceV395) DeleteRoutingRule(ctx context.Context, name string) (*http.Response, error) {
+	return s.client.RoutingRulesAPI.DeleteRoutingRules(ctx, name).Execute()
+}
+
+func (s *routingRuleServiceV395) GetRoutingRules(ctx context.Context) ([]sonatyperepoV382.RoutingRuleXO, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.RoutingRulesAPI.ListRoutingRules(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result []sonatyperepoV382.RoutingRuleXO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return result, httpResponse, nil
+}

--- a/internal/provider/common/saml_service.go
+++ b/internal/provider/common/saml_service.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// SamlService abstracts SAML configuration API across NXRM API client generations.
+type SamlService interface {
+	GetSamlConfiguration(ctx context.Context) (*sonatyperepoV382.SamlConfigurationXO, *http.Response, error)
+	PutSamlConfiguration(ctx context.Context, body sonatyperepoV382.SamlConfigurationXO) (*http.Response, error)
+	DeleteSamlConfiguration(ctx context.Context) (*http.Response, error)
+}
+
+// samlServiceV382 implements SamlService against NXRM API client V382 (targets NXRM < 3.94.0).
+type samlServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func NewSamlServiceV382(client *sonatyperepoV382.APIClient) SamlService {
+	return &samlServiceV382{client: client}
+}
+
+func (s *samlServiceV382) GetSamlConfiguration(ctx context.Context) (*sonatyperepoV382.SamlConfigurationXO, *http.Response, error) {
+	httpResponse, err := s.client.SecurityManagementSAMLAPI.GetSamlConfiguration(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	body, err := io.ReadAll(httpResponse.Body)
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	var result sonatyperepoV382.SamlConfigurationXO
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &result, httpResponse, nil
+}
+
+func (s *samlServiceV382) PutSamlConfiguration(ctx context.Context, body sonatyperepoV382.SamlConfigurationXO) (*http.Response, error) {
+	return s.client.SecurityManagementSAMLAPI.PutSamlConfiguration(ctx).Body(body).Execute()
+}
+
+func (s *samlServiceV382) DeleteSamlConfiguration(ctx context.Context) (*http.Response, error) {
+	return s.client.SecurityManagementSAMLAPI.DeleteSamlConfiguration(ctx).Execute()
+}
+
+// samlServiceV395 implements SamlService against NXRM API client V395 (targets NXRM 3.94.0+).
+type samlServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func NewSamlServiceV395(client *sonatyperepoV395.APIClient) SamlService {
+	return &samlServiceV395{client: client}
+}
+
+func (s *samlServiceV395) GetSamlConfiguration(ctx context.Context) (*sonatyperepoV382.SamlConfigurationXO, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.SecurityManagementSAMLAPI.ListSecuritySaml(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SamlConfigurationXO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *samlServiceV395) PutSamlConfiguration(ctx context.Context, body sonatyperepoV382.SamlConfigurationXO) (*http.Response, error) {
+	var v395Body sonatyperepoV395.SamlConfigurationXO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	return s.client.SecurityManagementSAMLAPI.UpdateSecuritySaml(ctx).SamlConfigurationXO(v395Body).Execute()
+}
+
+func (s *samlServiceV395) DeleteSamlConfiguration(ctx context.Context) (*http.Response, error) {
+	return s.client.SecurityManagementSAMLAPI.DeleteSecuritySaml(ctx).Execute()
+}

--- a/internal/provider/common/services.go
+++ b/internal/provider/common/services.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// Services bundles every domain service adapter, resolved once per provider
+// configuration to the NXRM API client generation matching the connected server.
+type Services struct {
+	Status          StatusService
+	Task            TaskService
+	Repository      RepositoryManagementService
+	BlobStore       BlobStoreService
+	Capability      CapabilityService
+	Privilege       PrivilegeService
+	ContentSelector ContentSelectorService
+	Role            RoleService
+	User            UserService
+	Configuration   ConfigurationService
+	RoutingRule     RoutingRuleService
+	CleanupPolicy   CleanupPolicyService
+	Saml            SamlService
+	Realms          RealmsService
+	AnonymousAccess AnonymousAccessService
+	SsrfProtection  SsrfProtectionService
+	UserTokens      UserTokensService
+	Certificates    CertificatesService
+	License         LicenseService
+	HttpSettings    HttpSettingsService
+}
+
+// NewServices resolves every domain service to the client generation appropriate for
+// the connected NXRM server's version. NXRM 3.94.0 and later use V395; anything older
+// uses V382. This is the only place a version is compared or a concrete client type is named.
+func NewServices(version SystemVersion, clientV382 *sonatyperepoV382.APIClient, clientV395 *sonatyperepoV395.APIClient) Services {
+	// SystemVersion.Patch/Build are int8 (max 127); 127 is used rather than 999 (which
+	// would overflow int8 and wrap negative, defeating the comparison) to ensure any
+	// 3.93.x.y patch/build stays on V382 and only 3.94.0+ selects V395.
+	if version.NewerThan(3, 93, 127, 127) {
+		return Services{
+			Status:          &statusServiceV395{client: clientV395},
+			Task:            &taskServiceV395{client: clientV395},
+			Repository:      &repositoryManagementServiceV395{client: clientV395},
+			BlobStore:       &blobStoreServiceV395{client: clientV395},
+			Capability:      &capabilityServiceV395{client: clientV395},
+			Privilege:       &privilegeServiceV395{client: clientV395},
+			ContentSelector: &contentSelectorServiceV395{client: clientV395},
+			Role:            &roleServiceV395{client: clientV395},
+			User:            &userServiceV395{client: clientV395},
+			Configuration:   &configurationServiceV395{client: clientV395},
+			RoutingRule:     &routingRuleServiceV395{client: clientV395},
+			CleanupPolicy:   NewCleanupPolicyServiceV395(clientV395),
+			Saml:            NewSamlServiceV395(clientV395),
+			Realms:          NewRealmsServiceV395(clientV395),
+			AnonymousAccess: NewAnonymousAccessServiceV395(clientV395),
+			SsrfProtection:  NewSsrfProtectionServiceV395(clientV395),
+			UserTokens:      NewUserTokensServiceV395(clientV395),
+			Certificates:    NewCertificatesServiceV395(clientV395),
+			License:         NewLicenseServiceV395(clientV395),
+			HttpSettings:    NewHttpSettingsServiceV395(clientV395),
+		}
+	}
+	return Services{
+		Status:          &statusServiceV382{client: clientV382},
+		Task:            &taskServiceV382{client: clientV382},
+		Repository:      &repositoryManagementServiceV382{client: clientV382},
+		BlobStore:       &blobStoreServiceV382{client: clientV382},
+		Capability:      &capabilityServiceV382{client: clientV382},
+		Privilege:       &privilegeServiceV382{client: clientV382},
+		ContentSelector: &contentSelectorServiceV382{client: clientV382},
+		Role:            &roleServiceV382{client: clientV382},
+		User:            &userServiceV382{client: clientV382},
+		Configuration:   &configurationServiceV382{client: clientV382},
+		RoutingRule:     &routingRuleServiceV382{client: clientV382},
+		CleanupPolicy:   NewCleanupPolicyServiceV382(clientV382),
+		Saml:            NewSamlServiceV382(clientV382),
+		Realms:          NewRealmsServiceV382(clientV382),
+		AnonymousAccess: NewAnonymousAccessServiceV382(clientV382),
+		SsrfProtection:  NewSsrfProtectionServiceV382(clientV382),
+		UserTokens:      NewUserTokensServiceV382(clientV382),
+		Certificates:    NewCertificatesServiceV382(clientV382),
+		License:         NewLicenseServiceV382(clientV382),
+		HttpSettings:    NewHttpSettingsServiceV382(clientV382),
+	}
+}

--- a/internal/provider/common/ssrf_protection_service.go
+++ b/internal/provider/common/ssrf_protection_service.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// SsrfProtectionService abstracts SSRF protection configuration API across NXRM API client generations.
+type SsrfProtectionService interface {
+	GetSsrfProtectionConfiguration(ctx context.Context) (*sonatyperepoV382.SsrfProtectionConfigurationXO, *http.Response, error)
+	UpdateSsrfProtectionConfiguration(ctx context.Context, body sonatyperepoV382.SsrfProtectionConfigurationXO) (*http.Response, error)
+}
+
+// ssrfProtectionServiceV382 implements SsrfProtectionService against NXRM API client V382 (targets NXRM < 3.94.0).
+type ssrfProtectionServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func NewSsrfProtectionServiceV382(client *sonatyperepoV382.APIClient) SsrfProtectionService {
+	return &ssrfProtectionServiceV382{client: client}
+}
+
+func (s *ssrfProtectionServiceV382) GetSsrfProtectionConfiguration(ctx context.Context) (*sonatyperepoV382.SsrfProtectionConfigurationXO, *http.Response, error) {
+	httpResponse, err := s.client.SecurityManagementSSRFProtectionAPI.GetConfiguration(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	body, err := io.ReadAll(httpResponse.Body)
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	var result sonatyperepoV382.SsrfProtectionConfigurationXO
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &result, httpResponse, nil
+}
+
+func (s *ssrfProtectionServiceV382) UpdateSsrfProtectionConfiguration(ctx context.Context, body sonatyperepoV382.SsrfProtectionConfigurationXO) (*http.Response, error) {
+	return s.client.SecurityManagementSSRFProtectionAPI.UpdateConfiguration(ctx).Body(body).Execute()
+}
+
+// ssrfProtectionServiceV395 implements SsrfProtectionService against NXRM API client V395 (targets NXRM 3.94.0+).
+type ssrfProtectionServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func NewSsrfProtectionServiceV395(client *sonatyperepoV395.APIClient) SsrfProtectionService {
+	return &ssrfProtectionServiceV395{client: client}
+}
+
+func (s *ssrfProtectionServiceV395) GetSsrfProtectionConfiguration(ctx context.Context) (*sonatyperepoV382.SsrfProtectionConfigurationXO, *http.Response, error) {
+	apiV395, httpResponse, err := s.client.SecurityManagementSSRFProtectionAPI.ListSecuritySsrfProtection(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	var result sonatyperepoV382.SsrfProtectionConfigurationXO
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+	return &result, httpResponse, nil
+}
+
+func (s *ssrfProtectionServiceV395) UpdateSsrfProtectionConfiguration(ctx context.Context, body sonatyperepoV382.SsrfProtectionConfigurationXO) (*http.Response, error) {
+	var v395Body sonatyperepoV395.SsrfProtectionConfigurationXO
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+	_, httpResponse, err := s.client.SecurityManagementSSRFProtectionAPI.UpdateSecuritySsrfProtection(ctx).SsrfProtectionConfigurationXO(v395Body).Execute()
+	return httpResponse, err
+}

--- a/internal/provider/common/status_service.go
+++ b/internal/provider/common/status_service.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// StatusService abstracts the Status API across NXRM API client generations.
+type StatusService interface {
+	// ClusterNodeCount returns the number of nodes reported by the cluster status checks endpoint.
+	ClusterNodeCount(ctx context.Context) (int, *http.Response, error)
+	// IsWritable calls the writable status check endpoint. Callers only care about the
+	// HTTP response status code, so no response body is returned.
+	IsWritable(ctx context.Context) (*http.Response, error)
+}
+
+// statusServiceV382 implements StatusService against NXRM API client V382 (targets NXRM < 3.94.0).
+type statusServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *statusServiceV382) ClusterNodeCount(ctx context.Context) (int, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.StatusAPI.GetClusterSystemStatusChecks(ctx).Execute()
+	if err != nil {
+		return 0, httpResponse, err
+	}
+	return len(apiResponse), httpResponse, nil
+}
+
+func (s *statusServiceV382) IsWritable(ctx context.Context) (*http.Response, error) {
+	return s.client.StatusAPI.IsWritable(ctx).Execute()
+}
+
+// statusServiceV395 implements StatusService against NXRM API client V395 (targets NXRM 3.94.0+).
+type statusServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *statusServiceV395) ClusterNodeCount(ctx context.Context) (int, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.StatusAPI.ListStatusCheckCluster(ctx).Execute()
+	if err != nil {
+		return 0, httpResponse, err
+	}
+	return len(apiResponse), httpResponse, nil
+}
+
+func (s *statusServiceV395) IsWritable(ctx context.Context) (*http.Response, error) {
+	return s.client.StatusAPI.ListStatusWritable(ctx).Execute()
+}

--- a/internal/provider/common/task_service.go
+++ b/internal/provider/common/task_service.go
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// TaskFrequencyApiModel is a generation-agnostic representation of a Task's Frequency,
+// shared by every NXRM API client generation.
+type TaskFrequencyApiModel struct {
+	Schedule       string
+	StartDate      *int64
+	TimeZoneOffset *string
+	RecurringDays  []int32
+	CronExpression *string
+}
+
+// TaskApiModel is a generation-agnostic representation of a Task, as returned by the
+// Tasks API. TaskService implementations translate the raw, per-generation client type
+// into this shape so that callers outside the adapter never depend on a specific
+// client generation.
+type TaskApiModel struct {
+	Id                    *string
+	Name                  *string
+	Type                  *string
+	Enabled               *bool
+	AlertEmail            *string
+	NotificationCondition *string
+	Schedule              *string
+	StartDate             *int64
+	TimeZoneOffset        *string
+	RecurringDays         []int32
+	CronExpression        *string
+	Properties            *map[string]string
+}
+
+// TaskCreateApiModel is a generation-agnostic representation of the request body used to
+// create a Task.
+type TaskCreateApiModel struct {
+	Name                  string
+	Enabled               bool
+	Frequency             TaskFrequencyApiModel
+	AlertEmail            *string
+	NotificationCondition string
+	Type                  string
+	Properties            *map[string]string
+}
+
+// TaskUpdateApiModel is a generation-agnostic representation of the request body used to
+// update a Task.
+type TaskUpdateApiModel struct {
+	Name                  string
+	Enabled               bool
+	Frequency             TaskFrequencyApiModel
+	AlertEmail            *string
+	NotificationCondition string
+	Type                  *string
+	Properties            *map[string]string
+}
+
+// TaskService abstracts the Tasks API across NXRM API client generations.
+type TaskService interface {
+	ListTasks(ctx context.Context) ([]TaskApiModel, *http.Response, error)
+	GetTaskById(ctx context.Context, id string) (*TaskApiModel, *http.Response, error)
+	CreateTask(ctx context.Context, plan *TaskCreateApiModel) (*TaskApiModel, *http.Response, error)
+	UpdateTask(ctx context.Context, id string, plan *TaskUpdateApiModel) (*http.Response, error)
+	DeleteTaskById(ctx context.Context, id string) (*http.Response, error)
+}
+
+func taskFrequencyToApiModelV382(f TaskFrequencyApiModel) sonatyperepoV382.FrequencyXO {
+	return sonatyperepoV382.FrequencyXO{
+		Schedule:       f.Schedule,
+		StartDate:      f.StartDate,
+		TimeZoneOffset: f.TimeZoneOffset,
+		RecurringDays:  f.RecurringDays,
+		CronExpression: f.CronExpression,
+	}
+}
+
+func taskFrequencyToApiModelV395(f TaskFrequencyApiModel) sonatyperepoV395.FrequencyXO {
+	return sonatyperepoV395.FrequencyXO{
+		Schedule:       f.Schedule,
+		StartDate:      f.StartDate,
+		TimeZoneOffset: f.TimeZoneOffset,
+		RecurringDays:  f.RecurringDays,
+		CronExpression: f.CronExpression,
+	}
+}
+
+func taskApiModelFromV382(api *sonatyperepoV382.TaskXO) *TaskApiModel {
+	if api == nil {
+		return nil
+	}
+	m := &TaskApiModel{
+		Id:                    api.Id,
+		Name:                  api.Name,
+		Type:                  api.Type,
+		Enabled:               api.Enabled,
+		AlertEmail:            api.AlertEmail,
+		NotificationCondition: api.NotificationCondition,
+		Schedule:              api.Schedule,
+		TimeZoneOffset:        api.TimeZoneOffset,
+		RecurringDays:         api.RecurringDays,
+		CronExpression:        api.CronExpression,
+		Properties:            api.Properties,
+	}
+	if api.StartDate != nil {
+		unix := api.StartDate.Unix()
+		m.StartDate = &unix
+	}
+	return m
+}
+
+func taskApiModelFromV395(api *sonatyperepoV395.TaskXO) *TaskApiModel {
+	if api == nil {
+		return nil
+	}
+	m := &TaskApiModel{
+		Id:                    api.Id,
+		Name:                  api.Name,
+		Type:                  api.Type,
+		Enabled:               api.Enabled,
+		AlertEmail:            api.AlertEmail,
+		NotificationCondition: api.NotificationCondition,
+		Schedule:              api.Schedule,
+		TimeZoneOffset:        api.TimeZoneOffset,
+		RecurringDays:         api.RecurringDays,
+		CronExpression:        api.CronExpression,
+		Properties:            api.Properties,
+	}
+	if api.StartDate != nil {
+		unix := api.StartDate.Unix()
+		m.StartDate = &unix
+	}
+	return m
+}
+
+// taskServiceV382 implements TaskService against NXRM API client V382 (targets NXRM < 3.94.0).
+type taskServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *taskServiceV382) ListTasks(ctx context.Context) ([]TaskApiModel, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.TasksAPI.GetTasks(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	tasks := make([]TaskApiModel, 0, len(apiResponse.Items))
+	for i := range apiResponse.Items {
+		tasks = append(tasks, *taskApiModelFromV382(&apiResponse.Items[i]))
+	}
+	return tasks, httpResponse, nil
+}
+
+func (s *taskServiceV382) GetTaskById(ctx context.Context, id string) (*TaskApiModel, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.TasksAPI.GetTaskById(ctx, id).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	return taskApiModelFromV382(apiResponse), httpResponse, nil
+}
+
+func (s *taskServiceV382) CreateTask(ctx context.Context, plan *TaskCreateApiModel) (*TaskApiModel, *http.Response, error) {
+	body := sonatyperepoV382.TaskTemplateXO{
+		Name:                  plan.Name,
+		Enabled:               plan.Enabled,
+		Frequency:             taskFrequencyToApiModelV382(plan.Frequency),
+		AlertEmail:            plan.AlertEmail,
+		NotificationCondition: plan.NotificationCondition,
+		Type:                  plan.Type,
+		Properties:            plan.Properties,
+	}
+	apiResponse, httpResponse, err := s.client.TasksAPI.CreateTask(ctx).Body(body).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	return taskApiModelFromV382(apiResponse), httpResponse, nil
+}
+
+func (s *taskServiceV382) UpdateTask(ctx context.Context, id string, plan *TaskUpdateApiModel) (*http.Response, error) {
+	body := sonatyperepoV382.UpdateTaskRequest{
+		Name:                  plan.Name,
+		Enabled:               plan.Enabled,
+		Frequency:             taskFrequencyToApiModelV382(plan.Frequency),
+		AlertEmail:            plan.AlertEmail,
+		NotificationCondition: plan.NotificationCondition,
+		Type:                  plan.Type,
+		Properties:            plan.Properties,
+	}
+	return s.client.TasksAPI.UpdateTask(ctx, id).Body(body).Execute()
+}
+
+func (s *taskServiceV382) DeleteTaskById(ctx context.Context, id string) (*http.Response, error) {
+	return s.client.TasksAPI.DeleteTaskById(ctx, id).Execute()
+}
+
+// taskServiceV395 implements TaskService against NXRM API client V395 (targets NXRM 3.94.0+).
+type taskServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *taskServiceV395) ListTasks(ctx context.Context) ([]TaskApiModel, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.TasksAPI.ListTasks(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	tasks := make([]TaskApiModel, 0, len(apiResponse.Items))
+	for i := range apiResponse.Items {
+		tasks = append(tasks, *taskApiModelFromV395(&apiResponse.Items[i]))
+	}
+	return tasks, httpResponse, nil
+}
+
+func (s *taskServiceV395) GetTaskById(ctx context.Context, id string) (*TaskApiModel, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.TasksAPI.GetTasks(ctx, id).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	return taskApiModelFromV395(apiResponse), httpResponse, nil
+}
+
+func (s *taskServiceV395) CreateTask(ctx context.Context, plan *TaskCreateApiModel) (*TaskApiModel, *http.Response, error) {
+	body := sonatyperepoV395.TaskTemplateXO{
+		Name:                  plan.Name,
+		Enabled:               plan.Enabled,
+		Frequency:             taskFrequencyToApiModelV395(plan.Frequency),
+		AlertEmail:            plan.AlertEmail,
+		NotificationCondition: plan.NotificationCondition,
+		Type:                  plan.Type,
+		Properties:            plan.Properties,
+	}
+	apiResponse, httpResponse, err := s.client.TasksAPI.CreateTasks(ctx).TaskTemplateXO(body).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+	return taskApiModelFromV395(apiResponse), httpResponse, nil
+}
+
+func (s *taskServiceV395) UpdateTask(ctx context.Context, id string, plan *TaskUpdateApiModel) (*http.Response, error) {
+	body := sonatyperepoV395.UpdateTasksRequest{
+		Name:                  plan.Name,
+		Enabled:               plan.Enabled,
+		Frequency:             taskFrequencyToApiModelV395(plan.Frequency),
+		AlertEmail:            plan.AlertEmail,
+		NotificationCondition: plan.NotificationCondition,
+		Type:                  plan.Type,
+		Properties:            plan.Properties,
+	}
+	return s.client.TasksAPI.UpdateTasks(ctx, id).UpdateTasksRequest(body).Execute()
+}
+
+func (s *taskServiceV395) DeleteTaskById(ctx context.Context, id string) (*http.Response, error) {
+	return s.client.TasksAPI.DeleteTasks(ctx, id).Execute()
+}

--- a/internal/provider/common/user_service.go
+++ b/internal/provider/common/user_service.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// UserService abstracts User management across NXRM API client generations.
+// Every method's request/response shape is expressed in terms of the V382
+// generated types -- the vocabulary the existing internal/provider/model
+// package's FromApiModel/ToApiCreateModel/ToApiUpdateModel methods are already
+// written against. The V395 adapter bridges to/from its own generated types
+// internally so that callers never need to know which generation is behind
+// the interface.
+type UserService interface {
+	CreateUser(ctx context.Context, body sonatyperepoV382.ApiCreateUser) (*sonatyperepoV382.ApiUser, *http.Response, error)
+	GetUsers(ctx context.Context, userId string, source string) ([]sonatyperepoV382.ApiUser, *http.Response, error)
+	UpdateUser(ctx context.Context, userId string, body sonatyperepoV382.ApiUser) (*http.Response, error)
+	ChangePassword(ctx context.Context, userId string, password string) (*http.Response, error)
+	DeleteUser(ctx context.Context, userId string) (*http.Response, error)
+}
+
+// userServiceV382 implements UserService against NXRM API client V382 (targets NXRM < 3.94.0).
+type userServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *userServiceV382) CreateUser(ctx context.Context, body sonatyperepoV382.ApiCreateUser) (*sonatyperepoV382.ApiUser, *http.Response, error) {
+	return s.client.SecurityManagementUsersAPI.CreateUser(ctx).Body(body).Execute()
+}
+
+func (s *userServiceV382) GetUsers(ctx context.Context, userId string, source string) ([]sonatyperepoV382.ApiUser, *http.Response, error) {
+	req := s.client.SecurityManagementUsersAPI.GetUsers(ctx)
+	// The generated builder methods always set the query param, even to an empty
+	// string, which NXRM then treats as an exact-match filter for "" rather than
+	// "unset" -- so an empty filter value must be omitted, not passed through.
+	if userId != "" {
+		req = req.UserId(userId)
+	}
+	if source != "" {
+		req = req.Source(source)
+	}
+	return req.Execute()
+}
+
+func (s *userServiceV382) UpdateUser(ctx context.Context, userId string, body sonatyperepoV382.ApiUser) (*http.Response, error) {
+	return s.client.SecurityManagementUsersAPI.UpdateUser(ctx, userId).Body(body).Execute()
+}
+
+func (s *userServiceV382) ChangePassword(ctx context.Context, userId string, password string) (*http.Response, error) {
+	return s.client.SecurityManagementUsersAPI.ChangePassword(ctx, userId).Body(password).Execute()
+}
+
+func (s *userServiceV382) DeleteUser(ctx context.Context, userId string) (*http.Response, error) {
+	return s.client.SecurityManagementUsersAPI.DeleteUser(ctx, userId).Execute()
+}
+
+// userServiceV395 implements UserService against NXRM API client V395 (targets NXRM 3.94.0+).
+type userServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *userServiceV395) CreateUser(ctx context.Context, body sonatyperepoV382.ApiCreateUser) (*sonatyperepoV382.ApiUser, *http.Response, error) {
+	// Bridge V382 ApiCreateUser -> V395 ApiCreateUser
+	var v395Body sonatyperepoV395.ApiCreateUser
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, nil, err
+	}
+
+	// V395 ApiCreateUser has required fields that are optional in V382.
+	// jsonBridge will drop fields that don't exist on the V395 side,
+	// but V395 requires emailAddress, firstName, lastName, password, userId.
+	// We need to explicitly map these from the V382 body (which may have nil pointers).
+	if body.EmailAddress != nil {
+		v395Body.EmailAddress = *body.EmailAddress
+	}
+	if body.FirstName != nil {
+		v395Body.FirstName = *body.FirstName
+	}
+	if body.LastName != nil {
+		v395Body.LastName = *body.LastName
+	}
+	if body.Password != nil {
+		v395Body.Password = *body.Password
+	}
+	if body.UserId != nil {
+		v395Body.UserId = *body.UserId
+	}
+	v395Body.Status = body.Status
+	v395Body.Roles = body.Roles
+
+	apiV395, httpResponse, err := s.client.SecurityManagementUsersAPI.CreateSecurityUsers(ctx).ApiCreateUser(v395Body).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 ApiUser -> V382 ApiUser
+	var result sonatyperepoV382.ApiUser
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &result, httpResponse, nil
+}
+
+func (s *userServiceV395) GetUsers(ctx context.Context, userId string, source string) ([]sonatyperepoV382.ApiUser, *http.Response, error) {
+	req := s.client.SecurityManagementUsersAPI.ListSecurityUsers(ctx)
+	// See userServiceV382.GetUsers: an empty filter value must be omitted, not
+	// passed through, since the builder always sets the query param otherwise.
+	if userId != "" {
+		req = req.UserId(userId)
+	}
+	if source != "" {
+		req = req.Source(source)
+	}
+	apiV395, httpResponse, err := req.Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 []ApiUser -> V382 []ApiUser
+	var result []sonatyperepoV382.ApiUser
+	if err := jsonBridge(apiV395, &result); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return result, httpResponse, nil
+}
+
+func (s *userServiceV395) UpdateUser(ctx context.Context, userId string, body sonatyperepoV382.ApiUser) (*http.Response, error) {
+	// Bridge V382 ApiUser -> V395 ApiUser
+	var v395Body sonatyperepoV395.ApiUser
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, err
+	}
+
+	// V395 ApiUser has Source and UserId as required fields (not pointers).
+	// jsonBridge will drop fields that don't exist on the V395 side,
+	// but V395 requires source, status, userId.
+	// We need to explicitly map these from the V382 body.
+	if body.Source != nil {
+		v395Body.Source = *body.Source
+	}
+	if body.UserId != nil {
+		v395Body.UserId = *body.UserId
+	}
+	v395Body.Status = body.Status
+
+	return s.client.SecurityManagementUsersAPI.UpdateSecurityUsers(ctx, userId).ApiUser(v395Body).Execute()
+}
+
+func (s *userServiceV395) ChangePassword(ctx context.Context, userId string, password string) (*http.Response, error) {
+	return s.client.SecurityManagementUsersAPI.UpdateSecurityUsersChangePassword(ctx, userId).Body(password).Execute()
+}
+
+func (s *userServiceV395) DeleteUser(ctx context.Context, userId string) (*http.Response, error) {
+	return s.client.SecurityManagementUsersAPI.DeleteSecurityUsers(ctx, userId).Execute()
+}

--- a/internal/provider/common/user_tokens_service.go
+++ b/internal/provider/common/user_tokens_service.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"context"
+	"net/http"
+
+	sonatyperepoV382 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
+)
+
+// UserTokensService abstracts the User Tokens API across NXRM API client generations.
+type UserTokensService interface {
+	// ServiceStatus retrieves current user token configuration.
+	ServiceStatus(ctx context.Context) (*sonatyperepoV382.UserTokensApiModel, *http.Response, error)
+	// SetServiceStatus updates user token configuration.
+	SetServiceStatus(ctx context.Context, body sonatyperepoV382.UserTokensApiModel) (*sonatyperepoV382.UserTokensApiModel, *http.Response, error)
+}
+
+// userTokensServiceV382 implements UserTokensService against NXRM API client V382 (targets NXRM < 3.94.0).
+type userTokensServiceV382 struct {
+	client *sonatyperepoV382.APIClient
+}
+
+func (s *userTokensServiceV382) ServiceStatus(ctx context.Context) (*sonatyperepoV382.UserTokensApiModel, *http.Response, error) {
+	return s.client.SecurityManagementUserTokensAPI.ServiceStatus(ctx).Execute()
+}
+
+func (s *userTokensServiceV382) SetServiceStatus(ctx context.Context, body sonatyperepoV382.UserTokensApiModel) (*sonatyperepoV382.UserTokensApiModel, *http.Response, error) {
+	return s.client.SecurityManagementUserTokensAPI.SetServiceStatus(ctx).Body(body).Execute()
+}
+
+// userTokensServiceV395 implements UserTokensService against NXRM API client V395 (targets NXRM 3.94.0+).
+type userTokensServiceV395 struct {
+	client *sonatyperepoV395.APIClient
+}
+
+func (s *userTokensServiceV395) ServiceStatus(ctx context.Context) (*sonatyperepoV382.UserTokensApiModel, *http.Response, error) {
+	v395Response, httpResponse, err := s.client.SecurityManagementUserTokensAPI.ListSecurityUserTokens(ctx).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 response to V382 shape
+	var v382Response sonatyperepoV382.UserTokensApiModel
+	if err := jsonBridge(v395Response, &v382Response); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &v382Response, httpResponse, nil
+}
+
+func (s *userTokensServiceV395) SetServiceStatus(ctx context.Context, body sonatyperepoV382.UserTokensApiModel) (*sonatyperepoV382.UserTokensApiModel, *http.Response, error) {
+	// Bridge V382 request to V395 shape
+	var v395Body sonatyperepoV395.UserTokensApiModel
+	if err := jsonBridge(body, &v395Body); err != nil {
+		return nil, nil, err
+	}
+
+	v395Response, httpResponse, err := s.client.SecurityManagementUserTokensAPI.UpdateSecurityUserTokens(ctx).UserTokensApiModel(v395Body).Execute()
+	if err != nil {
+		return nil, httpResponse, err
+	}
+
+	// Bridge V395 response to V382 shape
+	var v382Response sonatyperepoV382.UserTokensApiModel
+	if err := jsonBridge(v395Response, &v382Response); err != nil {
+		return nil, httpResponse, err
+	}
+
+	return &v382Response, httpResponse, nil
+}
+
+// NewUserTokensServiceV382 creates a V382 UserTokensService adapter.
+func NewUserTokensServiceV382(client *sonatyperepoV382.APIClient) UserTokensService {
+	return &userTokensServiceV382{client: client}
+}
+
+// NewUserTokensServiceV395 creates a V395 UserTokensService adapter.
+func NewUserTokensServiceV395(client *sonatyperepoV395.APIClient) UserTokensService {
+	return &userTokensServiceV395{client: client}
+}

--- a/internal/provider/content_selector/content_selector_data_source.go
+++ b/internal/provider/content_selector/content_selector_data_source.go
@@ -82,7 +82,7 @@ func (d *contentSelectorDataSource) Read(ctx context.Context, req datasource.Rea
 
 	ctx = d.AuthContext(ctx)
 
-	contentSelectorsResponse, httpResponse, err := d.Client.ContentSelectorsAPI.GetContentSelector(ctx, data.Name.ValueString()).Execute()
+	contentSelectorsResponse, httpResponse, err := d.Services.ContentSelector.GetContentSelector(ctx, data.Name.ValueString())
 
 	state := model.ContentSelectorModel{}
 	if err != nil {

--- a/internal/provider/content_selector/content_selector_resource.go
+++ b/internal/provider/content_selector/content_selector_resource.go
@@ -85,7 +85,7 @@ func (r *contentSelectorResource) Create(ctx context.Context, req resource.Creat
 	ctx = r.AuthContext(ctx)
 	apiBody := sonatyperepo.NewContentSelectorApiCreateRequest()
 	plan.MapToApiCreate(apiBody)
-	httpResponse, err := r.Client.ContentSelectorsAPI.CreateContentSelector(ctx).Body(*apiBody).Execute()
+	httpResponse, err := r.Services.ContentSelector.CreateContentSelector(ctx, *apiBody)
 
 	if err != nil {
 		errors.HandleAPIError(
@@ -127,7 +127,7 @@ func (r *contentSelectorResource) Read(ctx context.Context, req resource.ReadReq
 	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.ContentSelectorsAPI.GetContentSelector(ctx, state.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := r.Services.ContentSelector.GetContentSelector(ctx, state.Name.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusNotFound {
@@ -178,7 +178,7 @@ func (r *contentSelectorResource) Update(ctx context.Context, req resource.Updat
 	ctx = r.AuthContext(ctx)
 	apiBody := sonatyperepo.NewContentSelectorApiUpdateRequest()
 	plan.MapToApiUpdate(apiBody)
-	httpResponse, err := r.Client.ContentSelectorsAPI.UpdateContentSelector(ctx, state.Name.ValueString()).Body(*apiBody).Execute()
+	httpResponse, err := r.Services.ContentSelector.UpdateContentSelector(ctx, state.Name.ValueString(), *apiBody)
 
 	if err != nil {
 		errors.HandleAPIError(
@@ -218,7 +218,7 @@ func (r *contentSelectorResource) Delete(ctx context.Context, req resource.Delet
 
 	ctx = r.AuthContext(ctx)
 
-	httpResponse, err := r.Client.ContentSelectorsAPI.DeleteContentSelector(ctx, state.Name.ValueString()).Execute()
+	httpResponse, err := r.Services.ContentSelector.DeleteContentSelector(ctx, state.Name.ValueString())
 
 	// Handle Error
 	if err != nil {

--- a/internal/provider/content_selector/content_selectors_data_source.go
+++ b/internal/provider/content_selector/content_selectors_data_source.go
@@ -31,7 +31,6 @@ import (
 )
 
 // Ensure the implementation satisfies the expected interfaces.
-//
 var (
 	_ datasource.DataSource              = &contentSelectorsDataSource{}
 	_ datasource.DataSourceWithConfigure = &contentSelectorsDataSource{}
@@ -77,7 +76,7 @@ func (d *contentSelectorsDataSource) Read(ctx context.Context, req datasource.Re
 
 	ctx = d.AuthContext(ctx)
 
-	contentSelectorsResponse, httpResponse, err := d.Client.ContentSelectorsAPI.GetContentSelectors(ctx).Execute()
+	contentSelectorsResponse, httpResponse, err := d.Services.ContentSelector.GetContentSelectors(ctx)
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable list Content Selectors",

--- a/internal/provider/model/repository_yum.go
+++ b/internal/provider/model/repository_yum.go
@@ -142,7 +142,6 @@ func (m *RepositoryYumProxyModel) ToApiCreateModel() sonatyperepo.YumProxyReposi
 		Proxy:         sonatyperepo.ProxyAttributes{},
 		NegativeCache: sonatyperepo.NegativeCacheAttributes{},
 		HttpClient:    sonatyperepo.HttpClientAttributes{},
-		YumSigning:    &sonatyperepo.YumSigningRepositoriesAttributes{},
 	}
 	m.Storage.MapToApi(&apiModel.Storage)
 
@@ -164,6 +163,7 @@ func (m *RepositoryYumProxyModel) ToApiCreateModel() sonatyperepo.YumProxyReposi
 
 	// YUM Specific
 	if m.Yum != nil {
+		apiModel.YumSigning = &sonatyperepo.YumSigningRepositoriesAttributes{}
 		m.Yum.MapToApi(apiModel.YumSigning)
 	}
 
@@ -203,16 +203,16 @@ func (m *RepositoryYumGroupModel) FromApiModel(api sonatyperepo.YumGroupApiRepos
 
 func (m *RepositoryYumGroupModel) ToApiCreateModel() sonatyperepo.YumGroupRepositoryApiRequest {
 	apiModel := sonatyperepo.YumGroupRepositoryApiRequest{
-		Name:       m.Name.ValueString(),
-		Online:     m.Online.ValueBool(),
-		Storage:    sonatyperepo.StorageAttributes{},
-		YumSigning: sonatyperepo.NewYumSigningRepositoriesAttributesWithDefaults(),
+		Name:    m.Name.ValueString(),
+		Online:  m.Online.ValueBool(),
+		Storage: sonatyperepo.StorageAttributes{},
 	}
 	m.Storage.MapToApi(&apiModel.Storage)
 	m.Group.MapToApi(&apiModel.Group)
 
 	// YUM
 	if m.Yum != nil {
+		apiModel.YumSigning = &sonatyperepo.YumSigningRepositoriesAttributes{}
 		m.Yum.MapToApi(apiModel.YumSigning)
 	}
 

--- a/internal/provider/model/task.go
+++ b/internal/provider/model/task.go
@@ -17,8 +17,9 @@
 package model
 
 import (
+	"terraform-provider-sonatyperepo/internal/provider/common"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Task Frequency
@@ -31,7 +32,7 @@ type taskFrequency struct {
 	CronExpression types.String  `tfsdk:"cron_expression"`
 }
 
-func (f *taskFrequency) ToApiModel(api *v3.FrequencyXO) {
+func (f *taskFrequency) ToApiModel(api *common.TaskFrequencyApiModel) {
 	api.CronExpression = f.CronExpression.ValueStringPointer()
 	api.RecurringDays = make([]int32, 0)
 	for _, rd := range f.RecurringDays {
@@ -62,7 +63,7 @@ type TaskModelSimple struct {
 	Type types.String `tfsdk:"type"`
 }
 
-func (m *TaskModelSimple) MapFromApi(api *v3.TaskXO) {
+func (m *TaskModelSimple) MapFromApi(api *common.TaskApiModel) {
 	m.Id = types.StringPointerValue(api.Id)
 	m.Name = types.StringPointerValue(api.Name)
 	m.Type = types.StringPointerValue(api.Type)
@@ -79,19 +80,19 @@ type BaseTaskModel struct {
 	LastUpdated           types.String   `tfsdk:"last_updated"`
 }
 
-func (m *BaseTaskModel) MapFromApi(api *v3.TaskXO) {
+func (m *BaseTaskModel) MapFromApi(api *common.TaskApiModel) {
 	m.Id = types.StringPointerValue(api.Id)
 	if api.Name != nil {
 		m.Name = types.StringPointerValue(api.Name)
 	}
 }
 
-func (m *BaseTaskModel) toApiCreateModel() *v3.TaskTemplateXO {
-	api := v3.NewTaskTemplateXOWithDefaults()
+func (m *BaseTaskModel) toApiCreateModel() *common.TaskCreateApiModel {
+	api := &common.TaskCreateApiModel{}
 	api.Name = m.Name.ValueString()
 	api.Enabled = m.Enabled.ValueBool()
 	if m.Frequency != nil {
-		api.Frequency = *v3.NewFrequencyXO(m.Frequency.Schedule.ValueString())
+		api.Frequency = common.TaskFrequencyApiModel{Schedule: m.Frequency.Schedule.ValueString()}
 		m.Frequency.ToApiModel(&api.Frequency)
 	}
 	api.AlertEmail = m.AlertEmail.ValueStringPointer()
@@ -99,12 +100,12 @@ func (m *BaseTaskModel) toApiCreateModel() *v3.TaskTemplateXO {
 	return api
 }
 
-func (m *BaseTaskModel) toApiUpdateModel() *v3.UpdateTaskRequest {
-	api := v3.NewUpdateTaskRequestWithDefaults()
+func (m *BaseTaskModel) toApiUpdateModel() *common.TaskUpdateApiModel {
+	api := &common.TaskUpdateApiModel{}
 	api.Name = m.Name.ValueString()
 	api.Enabled = m.Enabled.ValueBool()
 	if m.Frequency != nil {
-		api.Frequency = *v3.NewFrequencyXO(m.Frequency.Schedule.ValueString())
+		api.Frequency = common.TaskFrequencyApiModel{Schedule: m.Frequency.Schedule.ValueString()}
 		m.Frequency.ToApiModel(&api.Frequency)
 	}
 	api.AlertEmail = m.AlertEmail.ValueStringPointer()

--- a/internal/provider/model/task_blobstore.go
+++ b/internal/provider/model/task_blobstore.go
@@ -20,8 +20,6 @@ import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Properties for blobstore.compact
@@ -47,7 +45,7 @@ type TaskBlobstoreCompactModel struct {
 	Properties *TaskPropertiesBlobstoreCompact `tfsdk:"properties"`
 }
 
-func (m *TaskBlobstoreCompactModel) ToApiCreateModel(version common.SystemVersion) *v3.TaskTemplateXO {
+func (m *TaskBlobstoreCompactModel) ToApiCreateModel(version common.SystemVersion) *common.TaskCreateApiModel {
 	api := m.toApiCreateModel()
 	api.Type = common.TASK_TYPE_BLOBSTORE_COMPACT.String()
 	if m.Properties != nil {
@@ -56,7 +54,7 @@ func (m *TaskBlobstoreCompactModel) ToApiCreateModel(version common.SystemVersio
 	return api
 }
 
-func (m *TaskBlobstoreCompactModel) ToApiUpdateModel(version common.SystemVersion) *v3.UpdateTaskRequest {
+func (m *TaskBlobstoreCompactModel) ToApiUpdateModel(version common.SystemVersion) *common.TaskUpdateApiModel {
 	api := m.toApiUpdateModel()
 	if m.Properties != nil {
 		api.Properties = m.Properties.GetFilteredPropertiesAsMap(version)

--- a/internal/provider/model/task_license.go
+++ b/internal/provider/model/task_license.go
@@ -18,8 +18,6 @@ package model
 
 import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
-
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Task Blobstore Compact
@@ -28,12 +26,12 @@ type TaskLicenseExpirationNotificationModel struct {
 	BaseTaskModel
 }
 
-func (m *TaskLicenseExpirationNotificationModel) ToApiCreateModel() *v3.TaskTemplateXO {
+func (m *TaskLicenseExpirationNotificationModel) ToApiCreateModel() *common.TaskCreateApiModel {
 	api := m.toApiCreateModel()
 	api.Type = common.TASK_TYPE_LICENSE_EXPIRATION_NOTIFICATION.String()
 	return api
 }
 
-func (m *TaskLicenseExpirationNotificationModel) ToApiUpdateModel() *v3.UpdateTaskRequest {
+func (m *TaskLicenseExpirationNotificationModel) ToApiUpdateModel() *common.TaskUpdateApiModel {
 	return m.toApiUpdateModel()
 }

--- a/internal/provider/model/task_malware.go
+++ b/internal/provider/model/task_malware.go
@@ -20,8 +20,6 @@ import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Properties for malware.remediator
@@ -42,7 +40,7 @@ type TaskMalwareRemediationModel struct {
 	Properties *TaskPropertiesMalwareRemediation `tfsdk:"properties"`
 }
 
-func (m *TaskMalwareRemediationModel) ToApiCreateModel(version common.SystemVersion) *v3.TaskTemplateXO {
+func (m *TaskMalwareRemediationModel) ToApiCreateModel(version common.SystemVersion) *common.TaskCreateApiModel {
 	api := m.toApiCreateModel()
 	api.Type = common.TASK_TYPE_MALWARE_REMEDIATOR.String()
 	if m.Properties != nil {
@@ -51,7 +49,7 @@ func (m *TaskMalwareRemediationModel) ToApiCreateModel(version common.SystemVers
 	return api
 }
 
-func (m *TaskMalwareRemediationModel) ToApiUpdateModel(version common.SystemVersion) *v3.UpdateTaskRequest {
+func (m *TaskMalwareRemediationModel) ToApiUpdateModel(version common.SystemVersion) *common.TaskUpdateApiModel {
 	api := m.toApiUpdateModel()
 	if m.Properties != nil {
 		api.Properties = m.Properties.GetFilteredPropertiesAsMap(version)

--- a/internal/provider/model/task_repair.go
+++ b/internal/provider/model/task_repair.go
@@ -20,8 +20,6 @@ import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Properties for create.browse.nodes
@@ -41,7 +39,7 @@ type TaskRepairCreateBrowseNodesModel struct {
 	Properties *TaskPropertiesRepairCreateBrowseNodes `tfsdk:"properties"`
 }
 
-func (m *TaskRepairCreateBrowseNodesModel) ToApiCreateModel(version common.SystemVersion) *v3.TaskTemplateXO {
+func (m *TaskRepairCreateBrowseNodesModel) ToApiCreateModel(version common.SystemVersion) *common.TaskCreateApiModel {
 	api := m.toApiCreateModel()
 	api.Type = common.TASK_TYPE_CREATE_BROWSE_NODES.String()
 	if m.Properties != nil {
@@ -50,7 +48,7 @@ func (m *TaskRepairCreateBrowseNodesModel) ToApiCreateModel(version common.Syste
 	return api
 }
 
-func (m *TaskRepairCreateBrowseNodesModel) ToApiUpdateModel(version common.SystemVersion) *v3.UpdateTaskRequest {
+func (m *TaskRepairCreateBrowseNodesModel) ToApiUpdateModel(version common.SystemVersion) *common.TaskUpdateApiModel {
 	api := m.toApiUpdateModel()
 	if m.Properties != nil {
 		api.Properties = m.Properties.GetFilteredPropertiesAsMap(version)

--- a/internal/provider/model/task_repository.go
+++ b/internal/provider/model/task_repository.go
@@ -20,8 +20,6 @@ import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Properties for repository.docker.gc
@@ -42,7 +40,7 @@ type TaskRepositoryDockerGcModel struct {
 	Properties *TaskPropertiesRepositoryDockerGc `tfsdk:"properties"`
 }
 
-func (m *TaskRepositoryDockerGcModel) ToApiCreateModel(version common.SystemVersion) *v3.TaskTemplateXO {
+func (m *TaskRepositoryDockerGcModel) ToApiCreateModel(version common.SystemVersion) *common.TaskCreateApiModel {
 	api := m.toApiCreateModel()
 	api.Type = common.TASK_TYPE_REPOSITORY_DOCKER_GC.String()
 	if m.Properties != nil {
@@ -51,7 +49,7 @@ func (m *TaskRepositoryDockerGcModel) ToApiCreateModel(version common.SystemVers
 	return api
 }
 
-func (m *TaskRepositoryDockerGcModel) ToApiUpdateModel(version common.SystemVersion) *v3.UpdateTaskRequest {
+func (m *TaskRepositoryDockerGcModel) ToApiUpdateModel(version common.SystemVersion) *common.TaskUpdateApiModel {
 	api := m.toApiUpdateModel()
 	if m.Properties != nil {
 		api.Properties = m.Properties.GetFilteredPropertiesAsMap(version)
@@ -76,7 +74,7 @@ type TaskRepositoryDockerUploadPurgeModel struct {
 	Properties *TaskPropertiesRepositoryDockerUploadPurge `tfsdk:"properties"`
 }
 
-func (m *TaskRepositoryDockerUploadPurgeModel) ToApiCreateModel(version common.SystemVersion) *v3.TaskTemplateXO {
+func (m *TaskRepositoryDockerUploadPurgeModel) ToApiCreateModel(version common.SystemVersion) *common.TaskCreateApiModel {
 	api := m.toApiCreateModel()
 	api.Type = common.TASK_TYPE_REPOSITORY_DOCKER_UPLOAD_PURGE.String()
 	if m.Properties != nil {
@@ -85,7 +83,7 @@ func (m *TaskRepositoryDockerUploadPurgeModel) ToApiCreateModel(version common.S
 	return api
 }
 
-func (m *TaskRepositoryDockerUploadPurgeModel) ToApiUpdateModel(version common.SystemVersion) *v3.UpdateTaskRequest {
+func (m *TaskRepositoryDockerUploadPurgeModel) ToApiUpdateModel(version common.SystemVersion) *common.TaskUpdateApiModel {
 	api := m.toApiUpdateModel()
 	if m.Properties != nil {
 		api.Properties = m.Properties.GetFilteredPropertiesAsMap(version)
@@ -120,7 +118,7 @@ type TaskRepositoryMavenRemoveSnapshotsModel struct {
 	Properties *TaskPropertiesRepositoryMavenRemoveSnapshots `tfsdk:"properties"`
 }
 
-func (m *TaskRepositoryMavenRemoveSnapshotsModel) ToApiCreateModel(version common.SystemVersion) *v3.TaskTemplateXO {
+func (m *TaskRepositoryMavenRemoveSnapshotsModel) ToApiCreateModel(version common.SystemVersion) *common.TaskCreateApiModel {
 	api := m.toApiCreateModel()
 	api.Type = common.TASK_TYPE_REPOSITORY_MAVEN_REMOVE_SNAPSHOTS.String()
 	if m.Properties != nil {
@@ -129,7 +127,7 @@ func (m *TaskRepositoryMavenRemoveSnapshotsModel) ToApiCreateModel(version commo
 	return api
 }
 
-func (m *TaskRepositoryMavenRemoveSnapshotsModel) ToApiUpdateModel(version common.SystemVersion) *v3.UpdateTaskRequest {
+func (m *TaskRepositoryMavenRemoveSnapshotsModel) ToApiUpdateModel(version common.SystemVersion) *common.TaskUpdateApiModel {
 	api := m.toApiUpdateModel()
 	if m.Properties != nil {
 		api.Properties = m.Properties.GetFilteredPropertiesAsMap(version)

--- a/internal/provider/privilege/privilege_common.go
+++ b/internal/provider/privilege/privilege_common.go
@@ -31,7 +31,6 @@ import (
 	tfschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 
 	"github.com/sonatype-nexus-community/terraform-provider-shared/errors"
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
@@ -80,11 +79,7 @@ func (r *privilegeResource) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Request Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Make API requet
 	httpResponse, err := r.PrivilegeType.DoCreateRequest(plan, r.Client, ctx)
@@ -128,11 +123,7 @@ func (r *privilegeResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	// Set API Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Make API Request
 	apiResponse, httpResponse, err := r.PrivilegeType.DoReadRequest(stateModel, r.Client, ctx)
@@ -177,11 +168,7 @@ func (r *privilegeResource) Update(ctx context.Context, req resource.UpdateReque
 	resp.Diagnostics.Append(diags...)
 
 	// Request Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Make API requet
 	httpResponse, err := r.PrivilegeType.DoUpdateRequest(planModel, stateModel, r.Client, ctx)
@@ -227,11 +214,7 @@ func (r *privilegeResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	// Request Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Make API request
 	privilegeNameStructField := reflect.Indirect(reflect.ValueOf(state)).FieldByName("Name").Interface()

--- a/internal/provider/privilege/privilege_wildcard_resource_test.go
+++ b/internal/provider/privilege/privilege_wildcard_resource_test.go
@@ -46,7 +46,7 @@ func TestAccPrivilegeWildcardResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "description", "some description"),
 					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "read_only", "false"),
 					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "type", privilege_type.TypeWildcard.String()),
-					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "pattern", "test-pattern"),
+					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "pattern", "nexus:test-pattern"),
 				),
 			},
 			// Update to full configuration
@@ -58,7 +58,7 @@ func TestAccPrivilegeWildcardResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "description", "updated description"),
 					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "read_only", "false"),
 					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "type", privilege_type.TypeWildcard.String()),
-					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "pattern", "updated-pattern-*"),
+					resource.TestCheckResourceAttr(resourceNamePrivilegeWildcard, "pattern", "nexus:updated-pattern-*"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -80,7 +80,7 @@ func buildPrivilegeWildcardResourceMinimal(randomString string) string {
 resource "%s" "p" {
 	name = "test-priv-wildcard-%s"
 	description = "some description"
-	pattern = "test-pattern"
+	pattern = "nexus:test-pattern"
 }`, resourceTypePrivilegeWildcard, randomString)
 }
 
@@ -89,6 +89,6 @@ func buildPrivilegeWildcardResourceComplete(randomString string) string {
 resource "%s" "p" {
 	name = "test-priv-wildcard-%s"
 	description = "updated description"
-	pattern = "updated-pattern-*"
+	pattern = "nexus:updated-pattern-*"
 }`, resourceTypePrivilegeWildcard, randomString)
 }

--- a/internal/provider/privilege/privileges_data_source.go
+++ b/internal/provider/privilege/privileges_data_source.go
@@ -30,8 +30,6 @@ import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
 	"terraform-provider-sonatyperepo/internal/provider/privilege/privilege_type"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -86,13 +84,9 @@ func (d *privilegesDataSource) Schema(_ context.Context, req datasource.SchemaRe
 func (d *privilegesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state model.PrivilegesModel
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	apiResponse, httpResponse, err := d.Client.SecurityManagementPrivilegesAPI.GetAllPrivileges(ctx).Execute()
+	apiResponse, httpResponse, err := d.Services.Privilege.GetAllPrivileges(ctx)
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable to list privileges",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -48,6 +48,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+	sonatyperepoV395 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395"
 )
 
 // Ensure SonatypeRepoProvider satisfies various provider interfaces.
@@ -245,6 +246,18 @@ func (p *SonatypeRepoProvider) apiClientConfiguration(nxrmUrl, apiBasePath strin
 	return configuration
 }
 
+func (p *SonatypeRepoProvider) apiClientConfigurationV395(nxrmUrl, apiBasePath string) *sonatyperepoV395.Configuration {
+	configuration := sonatyperepoV395.NewConfiguration()
+	configuration.UserAgent = "sonatyperepo-terraform/" + p.version
+	configuration.Servers = []sonatyperepoV395.ServerConfiguration{
+		{
+			URL:         fmt.Sprintf("%s%s", strings.TrimRight(nxrmUrl, "/"), strings.TrimRight(apiBasePath, "/")),
+			Description: "Sonatype Nexus Repository Server",
+		},
+	}
+	return configuration
+}
+
 func (p *SonatypeRepoProvider) createBootstrapClient(nxrmUrl, username, password, apiBasePath string, clusterStabilisationDelayMs int32) common.SonatypeDataSourceData {
 	configuration := p.apiClientConfiguration(nxrmUrl, apiBasePath)
 	client := sonatyperepo.NewAPIClient(configuration)
@@ -258,21 +271,28 @@ func (p *SonatypeRepoProvider) createBootstrapClient(nxrmUrl, username, password
 }
 
 func (p *SonatypeRepoProvider) createRealClient(nxrmUrl, apiBasePath string, ds *common.SonatypeDataSourceData) {
-	configuration := p.apiClientConfiguration(nxrmUrl, apiBasePath)
-
-	// 1. Initialize the custom transport
+	// 1. Initialize the custom transport, shared by both client generations
 	customTransport := &MiddlewareTransport{
 		Base:                        http.DefaultTransport,
 		ClusterStabilisationDelayMs: ds.ClusterSynchronisationDelayMs,
 		NodeCount:                   ds.NodeCount,
 	}
-
-	// 2. Create an HTTP client using the custom transport
-	configuration.HTTPClient = &http.Client{
+	httpClient := &http.Client{
 		Transport: customTransport,
 	}
 
+	// 2. V382 client (used for NXRM < 3.94.0)
+	configuration := p.apiClientConfiguration(nxrmUrl, apiBasePath)
+	configuration.HTTPClient = httpClient
 	ds.Client = sonatyperepo.NewAPIClient(configuration)
+
+	// 3. V395 client (used for NXRM 3.94.0+)
+	configurationV395 := p.apiClientConfigurationV395(nxrmUrl, apiBasePath)
+	configurationV395.HTTPClient = httpClient
+	clientV395 := sonatyperepoV395.NewAPIClient(configurationV395)
+
+	// 4. Resolve domain services to the client generation matching the connected server
+	ds.Services = common.NewServices(ds.NxrmVersion, ds.Client, clientV395)
 }
 
 // MiddlewareTransport wraps an existing RoundTripper to inject custom logic

--- a/internal/provider/repository/cleanup_policies.go
+++ b/internal/provider/repository/cleanup_policies.go
@@ -119,15 +119,11 @@ func (r *cleanupPolicyResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	requestPayload := buildRequestPayload(plan)
 
-	apiResponse, err := r.Client.CleanupPoliciesAPI.Create1(ctx).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.CleanupPolicy.Create(ctx, requestPayload)
 
 	// Handle Error
 	if err != nil {
@@ -176,7 +172,7 @@ func (r *cleanupPolicyResource) Read(ctx context.Context, req resource.ReadReque
 	cleanupPolicy, err := r.fetchCleanupPolicy(ctx, state.Name.ValueString())
 	if err != nil {
 		// Check if this is a 404 error by attempting to get the HTTP response
-		httpResponse, _ := r.Client.CleanupPoliciesAPI.GetCleanupPolicyByName(ctx, state.Name.ValueString()).Execute()
+		httpResponse, _ := r.Services.CleanupPolicy.GetByName(ctx, state.Name.ValueString())
 		if httpResponse != nil && httpResponse.StatusCode == 404 {
 			resp.State.RemoveResource(ctx)
 			errors.HandleAPIWarning(
@@ -231,8 +227,7 @@ func (r *cleanupPolicyResource) Update(ctx context.Context, req resource.UpdateR
 
 	// Build request payload and make API call
 	requestPayload := buildRequestPayload(plan)
-	apiRequest := r.Client.CleanupPoliciesAPI.Update2(ctx, state.Name.ValueString()).Body(requestPayload)
-	apiResponse, err := apiRequest.Execute()
+	apiResponse, err := r.Services.CleanupPolicy.Update(ctx, state.Name.ValueString(), requestPayload)
 
 	// Handle API response
 	if err != nil {
@@ -257,14 +252,10 @@ func (r *cleanupPolicyResource) Delete(ctx context.Context, req resource.DeleteR
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Delete API Call
-	apiResponse, err := r.Client.CleanupPoliciesAPI.DeletePolicyByName(ctx, state.Name.ValueString()).Execute()
+	apiResponse, err := r.Services.CleanupPolicy.DeleteByName(ctx, state.Name.ValueString())
 
 	// Handle Error(s)
 	if err != nil {
@@ -422,7 +413,7 @@ func updateCriteriaFromAPI(criteria *model.CleanupPolicyCriteriaModel, cleanupPo
 
 // fetchCleanupPolicy retrieves and parses the cleanup policy from the API
 func (r *cleanupPolicyResource) fetchCleanupPolicy(ctx context.Context, name string) (*sonatyperepo.CleanupPolicyResourceXO, error) {
-	httpResponse, err := r.Client.CleanupPoliciesAPI.GetCleanupPolicyByName(ctx, name).Execute()
+	httpResponse, err := r.Services.CleanupPolicy.GetByName(ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/repository/format/alpine.go
+++ b/internal/provider/repository/format/alpine.go
@@ -155,8 +155,11 @@ func (f *AlpineRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAlpineProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateAlpineProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateAlpineProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *AlpineRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -164,11 +167,11 @@ func (f *AlpineRepositoryFormatProxy) DoReadRequest(state any, apiClient common.
 	stateModel := (state).(model.RepositoryAlpineProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetAlpineProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetAlpineProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *AlpineRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -178,18 +181,21 @@ func (f *AlpineRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCl
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAlpineProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Update
-	return apiClient.UpdateAlpineProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateAlpineProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for Alpine Proxy repositories
 func (f *AlpineRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetAlpineProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetAlpineProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *AlpineRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -220,6 +226,26 @@ func (f *AlpineRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any
 	if state != nil {
 		stateModel = (state).(model.RepositoryAlpineProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.AlpineProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.AlpineProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/alpine.go
+++ b/internal/provider/repository/format/alpine.go
@@ -65,27 +65,27 @@ func (f *AlpineRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted Alpine Format Functions
 // --------------------------------------------
-func (f *AlpineRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AlpineRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAlpineHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateAlpineHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateAlpineHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *AlpineRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AlpineRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAlpineHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAlpineHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAlpineHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *AlpineRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AlpineRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAlpineHostedModel)
 
@@ -93,7 +93,7 @@ func (f *AlpineRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiC
 	stateModel := (state).(model.RepositoryAlpineHostedModel)
 
 	// Call API to Update
-	return apiClient.RepositoryManagementAPI.UpdateAlpineHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateAlpineHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *AlpineRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -139,9 +139,9 @@ func (f *AlpineRepositoryFormatHosted) UpdateStateFromPlanForNonApiFields(plan, 
 }
 
 // DoImportRequest implements the import functionality for Alpine Hosted repositories
-func (f *AlpineRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AlpineRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAlpineHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAlpineHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -151,27 +151,27 @@ func (f *AlpineRepositoryFormatHosted) DoImportRequest(repositoryName string, ap
 // --------------------------------------------
 // PROXY Alpine Format Functions
 // --------------------------------------------
-func (f *AlpineRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AlpineRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAlpineProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateAlpineProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateAlpineProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *AlpineRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AlpineRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAlpineProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAlpineProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAlpineProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *AlpineRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AlpineRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAlpineProxyModel)
 
@@ -179,13 +179,13 @@ func (f *AlpineRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCl
 	stateModel := (state).(model.RepositoryAlpineProxyModel)
 
 	// Call API to Update
-	return apiClient.RepositoryManagementAPI.UpdateAlpineProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateAlpineProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Alpine Proxy repositories
-func (f *AlpineRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AlpineRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAlpineProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAlpineProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -293,27 +293,27 @@ func (f *AlpineRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(sta
 // --------------------------------------------
 // GROUP Alpine Format Functions
 // --------------------------------------------
-func (f *AlpineRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AlpineRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAlpineGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateAlpineGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateAlpineGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *AlpineRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AlpineRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAlpineGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAlpineGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAlpineGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *AlpineRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AlpineRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAlpineGroupModel)
 
@@ -321,7 +321,7 @@ func (f *AlpineRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiCl
 	stateModel := (state).(model.RepositoryAlpineGroupModel)
 
 	// Call API to Update
-	return apiClient.RepositoryManagementAPI.UpdateAlpineGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateAlpineGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *AlpineRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -367,9 +367,9 @@ func (f *AlpineRepositoryFormatGroup) UpdateStateFromApi(state any, api any) any
 }
 
 // DoImportRequest implements the import functionality for Alpine Group repositories
-func (f *AlpineRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AlpineRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAlpineGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAlpineGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -384,7 +384,7 @@ func alpineSchemaAttributes() map[string]tfschema.Attribute {
 		"alpine": schema.ResourceOptionalSingleNestedAttribute(
 			"Alpine specific configuration for this Repository",
 			map[string]tfschema.Attribute{
-				"key_pair": schema.ResourceOptionalString(
+				"key_pair": schema.ResourceRequiredString(
 					"RSA private key in PEM format used to sign the repository index",
 				),
 				"passphrase": schema.ResourceSensitiveOptionalStringWithPlanModifier(

--- a/internal/provider/repository/format/alpine.go
+++ b/internal/provider/repository/format/alpine.go
@@ -239,6 +239,7 @@ func (f *AlpineRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
 				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 			}

--- a/internal/provider/repository/format/ansible_galaxy.go
+++ b/internal/provider/repository/format/ansible_galaxy.go
@@ -61,27 +61,27 @@ func (f *AnsibleGalaxyRepositoryFormat) ResourceName(repoType RepositoryType) st
 // --------------------------------------------
 // Hosted Ansible Galaxy Format Functions
 // --------------------------------------------
-func (f *AnsibleGalaxyRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAnsibleGalaxyHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateAnsiblegalaxyHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateAnsiblegalaxyHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *AnsibleGalaxyRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAnsibleGalaxyHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAnsiblegalaxyHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAnsiblegalaxyHostedRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *AnsibleGalaxyRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAnsibleGalaxyHostedModel)
 
@@ -89,7 +89,7 @@ func (f *AnsibleGalaxyRepositoryFormatHosted) DoUpdateRequest(plan any, state an
 	stateModel := (state).(model.RepositoryAnsibleGalaxyHostedModel)
 
 	// Call API to Update
-	return apiClient.RepositoryManagementAPI.UpdateAnsiblegalaxyHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateAnsiblegalaxyHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *AnsibleGalaxyRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -123,9 +123,9 @@ func (f *AnsibleGalaxyRepositoryFormatHosted) UpdateStateFromApi(state, api any)
 }
 
 // DoImportRequest implements the import functionality for Ansible Galaxy Hosted repositories
-func (f *AnsibleGalaxyRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAnsiblegalaxyHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAnsiblegalaxyHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -135,27 +135,27 @@ func (f *AnsibleGalaxyRepositoryFormatHosted) DoImportRequest(repositoryName str
 // --------------------------------------------
 // Proxy Ansible Galaxy Format Functions
 // --------------------------------------------
-func (f *AnsibleGalaxyRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAnsibleGalaxyProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateAnsiblegalaxyProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateAnsiblegalaxyProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *AnsibleGalaxyRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAnsibleGalaxyProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAnsiblegalaxyProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAnsiblegalaxyProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *AnsibleGalaxyRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAnsibleGalaxyProxyModel)
 
@@ -163,13 +163,13 @@ func (f *AnsibleGalaxyRepositoryFormatProxy) DoUpdateRequest(plan any, state any
 	stateModel := (state).(model.RepositoryAnsibleGalaxyProxyModel)
 
 	// Call API to Update
-	return apiClient.RepositoryManagementAPI.UpdateAnsiblegalaxyProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateAnsiblegalaxyProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Ansible Galaxy Proxy repositories
-func (f *AnsibleGalaxyRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAnsiblegalaxyProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAnsiblegalaxyProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -226,27 +226,27 @@ func (f *AnsibleGalaxyRepositoryFormatProxy) SupportsRepositoryFirewall() bool {
 // --------------------------------------------
 // Group Ansible Galaxy Format Functions
 // --------------------------------------------
-func (f *AnsibleGalaxyRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAnsibleGalaxyGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateAnsiblegalaxyGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateAnsiblegalaxyGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *AnsibleGalaxyRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAnsibleGalaxyGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAnsiblegalaxyGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAnsiblegalaxyGroupRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *AnsibleGalaxyRepositoryFormatGroup) DoUpdateRequest(plan, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatGroup) DoUpdateRequest(plan, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAnsibleGalaxyGroupModel)
 
@@ -254,7 +254,7 @@ func (f *AnsibleGalaxyRepositoryFormatGroup) DoUpdateRequest(plan, state any, ap
 	stateModel := (state).(model.RepositoryAnsibleGalaxyGroupModel)
 
 	// Call API to Update
-	return apiClient.RepositoryManagementAPI.UpdateAnsiblegalaxyGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateAnsiblegalaxyGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *AnsibleGalaxyRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -288,9 +288,9 @@ func (f *AnsibleGalaxyRepositoryFormatGroup) UpdateStateFromApi(state, api any) 
 }
 
 // DoImportRequest implements the import functionality for Ansible Galaxy Group repositories
-func (f *AnsibleGalaxyRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AnsibleGalaxyRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAnsiblegalaxyGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAnsiblegalaxyGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/apt.go
+++ b/internal/provider/repository/format/apt.go
@@ -60,27 +60,27 @@ func (f *AptRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // HOSTED APT Format Functions
 // --------------------------------------------
-func (f *AptRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AptRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAptHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateAptHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateAptHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *AptRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AptRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAptHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAptHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAptHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *AptRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AptRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAptHostedModel)
 
@@ -88,13 +88,13 @@ func (f *AptRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClie
 	stateModel := (state).(model.RepositoryAptHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateAptHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateAptHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for APT Hosted repositories
-func (f *AptRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AptRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAptHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAptHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -163,27 +163,27 @@ func (f *AptRepositoryFormatHosted) UpdateStateFromPlanForNonApiFields(plan, sta
 // --------------------------------------------
 // PROXY APT Format Functions
 // --------------------------------------------
-func (f *AptRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AptRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAptProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateAptProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateAptProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *AptRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AptRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryAptProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAptProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAptProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *AptRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *AptRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryAptProxyModel)
 
@@ -191,13 +191,13 @@ func (f *AptRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryAptProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateAptProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateAptProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for APT Proxy repositories
-func (f *AptRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *AptRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetAptProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetAptProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/cargo.go
+++ b/internal/provider/repository/format/cargo.go
@@ -225,6 +225,7 @@ func (f *CargoRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
 				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 			}

--- a/internal/provider/repository/format/cargo.go
+++ b/internal/provider/repository/format/cargo.go
@@ -64,27 +64,27 @@ func (f *CargoRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted Cargo Format Functions
 // --------------------------------------------
-func (f *CargoRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CargoRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorCargoHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateCargoHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateCargoHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *CargoRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CargoRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositorCargoHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCargoHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCargoHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *CargoRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CargoRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorCargoHostedModel)
 
@@ -92,12 +92,12 @@ func (f *CargoRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiCl
 	stateModel := (state).(model.RepositorCargoHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateCargoHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateCargoHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
-func (f *CargoRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CargoRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCargoHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCargoHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -137,27 +137,27 @@ func (f *CargoRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any
 // --------------------------------------------
 // PROXY Cargo Format Functions
 // --------------------------------------------
-func (f *CargoRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CargoRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCargoProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateCargoProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateCargoProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *CargoRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CargoRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryCargoProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCargoProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCargoProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *CargoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CargoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCargoProxyModel)
 
@@ -165,13 +165,13 @@ func (f *CargoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryCargoProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateCargoProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateCargoProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Cargo Proxy repositories
-func (f *CargoRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CargoRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCargoProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCargoProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -279,27 +279,27 @@ func (f *CargoRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(stat
 // --------------------------------------------
 // GROUP Cargo Format Functions
 // --------------------------------------------
-func (f *CargoRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CargoRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCargoGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateCargoGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateCargoGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *CargoRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CargoRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryCargoGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCargoGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCargoGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *CargoRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CargoRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCargoGroupModel)
 
@@ -307,7 +307,7 @@ func (f *CargoRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryCargoGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateCargoGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateCargoGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *CargoRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {

--- a/internal/provider/repository/format/cargo.go
+++ b/internal/provider/repository/format/cargo.go
@@ -141,8 +141,11 @@ func (f *CargoRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCargoProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateCargoProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateCargoProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *CargoRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -150,11 +153,11 @@ func (f *CargoRepositoryFormatProxy) DoReadRequest(state any, apiClient common.R
 	stateModel := (state).(model.RepositoryCargoProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetCargoProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetCargoProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *CargoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -164,18 +167,21 @@ func (f *CargoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryCargoProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateCargoProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateCargoProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for Cargo Proxy repositories
 func (f *CargoRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetCargoProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetCargoProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *CargoRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -206,6 +212,26 @@ func (f *CargoRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if state != nil {
 		stateModel = (state).(model.RepositoryCargoProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.CargoProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.CargoProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/cocoapods.go
+++ b/internal/provider/repository/format/cocoapods.go
@@ -53,27 +53,27 @@ func (f *CocoaPodsRepositoryFormat) ResourceName(repoType RepositoryType) string
 // --------------------------------------------
 // PROXY CocoaPods Format Functions
 // --------------------------------------------
-func (f *CocoaPodsRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CocoaPodsRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCocoaPodsProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateCocoapodsProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateCocoapodsProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *CocoaPodsRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CocoaPodsRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryCocoaPodsProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCocoapodsProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCocoapodsProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *CocoaPodsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CocoaPodsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCocoaPodsProxyModel)
 
@@ -81,13 +81,13 @@ func (f *CocoaPodsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, ap
 	stateModel := (state).(model.RepositoryCocoaPodsProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateCocoapodsProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateCocoapodsProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for NPM Proxy repositories
-func (f *CocoaPodsRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CocoaPodsRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCocoapodsProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCocoapodsProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/common.go
+++ b/internal/provider/repository/format/common.go
@@ -87,6 +87,12 @@ func (f *BaseRepositoryFormat) DoImportRequest(repositoryName string, apiClient 
 // ValidateRepositoryForImport validates that the repository matches the expected format and type
 // This base implementation uses reflection to extract Format and Type fields from the API repository struct
 func (f *BaseRepositoryFormat) ValidateRepositoryForImport(repositoryData any, expectedFormat string, expectedType RepositoryType) error {
+	// Proxy formats wrap the repository together with its inline firewall mode (NXRM 3.94+);
+	// unwrap it so reflection below sees the underlying API struct's Format/Type fields.
+	if wrapped, ok := repositoryData.(ProxyApiResponseWithFirewall); ok {
+		repositoryData = wrapped.Repository
+	}
+
 	// Use reflection to get Format and Type fields from the repository data
 	v := reflect.ValueOf(repositoryData)
 

--- a/internal/provider/repository/format/common.go
+++ b/internal/provider/repository/format/common.go
@@ -63,9 +63,9 @@ const (
 // --------------------------------------------
 type BaseRepositoryFormat struct{}
 
-func (f *BaseRepositoryFormat) DoDeleteRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *BaseRepositoryFormat) DoDeleteRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Call API to Delete
-	return apiClient.RepositoryManagementAPI.DeleteRepository(ctx, repositoryName).Execute()
+	return apiClient.DeleteRepository(ctx, repositoryName)
 }
 
 func (f *BaseRepositoryFormat) ApiCreateSuccessResponseCodes() []int {
@@ -78,7 +78,7 @@ func (f *BaseRepositoryFormat) ValidatePlanForNxrmVersion(plan any, version comm
 
 // DoImportRequest provides a base implementation for repository import
 // This can be overridden by specific formats if needed
-func (f *BaseRepositoryFormat) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *BaseRepositoryFormat) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// For base implementation, we can't determine the specific repository type
 	// This should be overridden by each format implementation
 	return nil, nil, fmt.Errorf("import not implemented for this repository format")
@@ -185,11 +185,11 @@ func (f *BaseRepositoryFormat) UpdateStateFromPlanForNonApiFields(plan, state an
 // RepositoryFormat that all Repository Formats must implement
 // --------------------------------------------
 type RepositoryFormat interface {
-	DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error)
-	DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error)
-	DoDeleteRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error)
-	DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error)
-	DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error)
+	DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error)
+	DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error)
+	DoDeleteRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error)
+	DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error)
+	DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error)
 	ValidateRepositoryForImport(repositoryData any, expectedFormat string, expectedType RepositoryType) error
 	ApiCreateSuccessResponseCodes() []int
 	FormatSchemaAttributes() map[string]tfschema.Attribute

--- a/internal/provider/repository/format/composer.go
+++ b/internal/provider/repository/format/composer.go
@@ -57,8 +57,11 @@ func (f *ComposerRepositoryFormat) DoCreateRequest(plan any, apiClient common.Re
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryComposerProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateComposerProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateComposerProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *ComposerRepositoryFormat) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -66,11 +69,11 @@ func (f *ComposerRepositoryFormat) DoReadRequest(state any, apiClient common.Rep
 	stateModel := (state).(model.RepositoryComposerProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetComposerProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetComposerProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *ComposerRepositoryFormat) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -80,18 +83,21 @@ func (f *ComposerRepositoryFormat) DoUpdateRequest(plan any, state any, apiClien
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryComposerProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateComposerProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateComposerProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for NPM Proxy repositories
 func (f *ComposerRepositoryFormat) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetComposerProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetComposerProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *ComposerRepositoryFormat) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -120,6 +126,26 @@ func (f *ComposerRepositoryFormat) UpdateStateFromApi(state any, api any) any {
 	if state != nil {
 		stateModel = (state).(model.RepositoryComposerProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.SimpleApiProxyRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/composer.go
+++ b/internal/provider/repository/format/composer.go
@@ -53,27 +53,27 @@ func (f *ComposerRepositoryFormat) ResourceName(repoType RepositoryType) string 
 // --------------------------------------------
 // PROXY Composer Format Functions
 // --------------------------------------------
-func (f *ComposerRepositoryFormat) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *ComposerRepositoryFormat) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryComposerProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateComposerProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateComposerProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *ComposerRepositoryFormat) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *ComposerRepositoryFormat) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryComposerProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetComposerProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetComposerProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *ComposerRepositoryFormat) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *ComposerRepositoryFormat) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryComposerProxyModel)
 
@@ -81,13 +81,13 @@ func (f *ComposerRepositoryFormat) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryComposerProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateComposerProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateComposerProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for NPM Proxy repositories
-func (f *ComposerRepositoryFormat) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *ComposerRepositoryFormat) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetComposerProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetComposerProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/composer.go
+++ b/internal/provider/repository/format/composer.go
@@ -139,6 +139,7 @@ func (f *ComposerRepositoryFormat) UpdateStateFromApi(state any, api any) any {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
 				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 			}

--- a/internal/provider/repository/format/conan.go
+++ b/internal/provider/repository/format/conan.go
@@ -67,27 +67,27 @@ func (f *ConanRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted Conan Format Functions
 // --------------------------------------------
-func (f *ConanRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *ConanRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorConanHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateConanHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateConanHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *ConanRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *ConanRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositorConanHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetConanHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetConanHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *ConanRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *ConanRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorConanHostedModel)
 
@@ -95,12 +95,12 @@ func (f *ConanRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiCl
 	stateModel := (state).(model.RepositorConanHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateConanHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateConanHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
-func (f *ConanRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *ConanRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetConanHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetConanHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -140,27 +140,27 @@ func (f *ConanRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any
 // --------------------------------------------
 // PROXY Conan Format Functions
 // --------------------------------------------
-func (f *ConanRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *ConanRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryConanProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateConanProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateConanProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *ConanRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *ConanRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryConanProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetConanProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetConanProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *ConanRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *ConanRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryConanProxyModel)
 
@@ -168,13 +168,13 @@ func (f *ConanRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryConanProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateConanProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateConanProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Conan Proxy repositories
-func (f *ConanRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *ConanRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetConanProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetConanProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -282,27 +282,27 @@ func (f *ConanRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(stat
 // --------------------------------------------
 // GROUP Conan Format Functions
 // --------------------------------------------
-func (f *ConanRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *ConanRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryConanGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateConanGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateConanGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *ConanRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *ConanRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryConanGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetConanGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetConanGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *ConanRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *ConanRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryConanGroupModel)
 
@@ -310,7 +310,7 @@ func (f *ConanRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryConanGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateConanGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateConanGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *ConanRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {

--- a/internal/provider/repository/format/conda.go
+++ b/internal/provider/repository/format/conda.go
@@ -53,27 +53,27 @@ func (f *CondaRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // PROXY Conda Format Functions
 // --------------------------------------------
-func (f *CondaRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CondaRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCondaProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateCondaProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateCondaProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *CondaRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CondaRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryCondaProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCondaProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCondaProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *CondaRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *CondaRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCondaProxyModel)
 
@@ -81,13 +81,13 @@ func (f *CondaRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryCondaProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateCondaProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateCondaProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Conda Proxy repositories
-func (f *CondaRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *CondaRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetCondaProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetCondaProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/docker.go
+++ b/internal/provider/repository/format/docker.go
@@ -253,6 +253,7 @@ func (f *DockerRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
 				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 			}

--- a/internal/provider/repository/format/docker.go
+++ b/internal/provider/repository/format/docker.go
@@ -168,8 +168,11 @@ func (f *DockerRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryDockerProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateDockerProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateDockerProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *DockerRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -177,11 +180,11 @@ func (f *DockerRepositoryFormatProxy) DoReadRequest(state any, apiClient common.
 	stateModel := (state).(model.RepositoryDockerProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetDockerProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetDockerProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *DockerRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -191,18 +194,21 @@ func (f *DockerRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCl
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryDockerProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateDockerProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateDockerProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for Docker Proxy repositories
 func (f *DockerRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetDockerProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetDockerProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *DockerRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -234,6 +240,26 @@ func (f *DockerRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any
 	if state != nil {
 		stateModel = (state).(model.RepositoryDockerProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.DockerProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.DockerProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/docker.go
+++ b/internal/provider/repository/format/docker.go
@@ -74,20 +74,20 @@ func (f *DockerRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted Docker Format Functions
 // --------------------------------------------
-func (f *DockerRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *DockerRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryDockerHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateDockerHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateDockerHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *DockerRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *DockerRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryDockerHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetDockerHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetDockerHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
@@ -103,7 +103,7 @@ func (f *DockerRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonat
 	return *apiResponse, httpResponse, err
 }
 
-func (f *DockerRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *DockerRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryDockerHostedModel)
 
@@ -111,13 +111,13 @@ func (f *DockerRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiC
 	stateModel := (state).(model.RepositoryDockerHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateDockerHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateDockerHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Docker Hosted repositories
-func (f *DockerRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *DockerRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetDockerHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetDockerHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -164,27 +164,27 @@ func (f *DockerRepositoryFormatHosted) ValidatePlanForNxrmVersion(plan any, vers
 // --------------------------------------------
 // PROXY Docker Format Functions
 // --------------------------------------------
-func (f *DockerRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *DockerRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryDockerProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateDockerProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateDockerProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *DockerRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *DockerRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryDockerProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetDockerProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetDockerProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *DockerRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *DockerRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryDockerProxyModel)
 
@@ -192,13 +192,13 @@ func (f *DockerRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCl
 	stateModel := (state).(model.RepositoryDockerProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateDockerProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateDockerProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Docker Proxy repositories
-func (f *DockerRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *DockerRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetDockerProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetDockerProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -317,27 +317,27 @@ func (f *DockerRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(sta
 // --------------------------------------------
 // GROUP Docker Format Functions
 // --------------------------------------------
-func (f *DockerRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *DockerRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryDockerGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateDockerGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateDockerGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *DockerRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *DockerRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryDockerGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetDockerGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetDockerGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *DockerRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *DockerRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryDockerGroupModel)
 
@@ -345,13 +345,13 @@ func (f *DockerRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiCl
 	stateModel := (state).(model.RepositoryDockerGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateDockerGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateDockerGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Docker Group repositories
-func (f *DockerRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *DockerRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetDockerGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetDockerGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/git_lfs.go
+++ b/internal/provider/repository/format/git_lfs.go
@@ -53,27 +53,27 @@ func (f *GitLfsRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted Git LFS Format Functions
 // --------------------------------------------
-func (f *GitLfsRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *GitLfsRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGitLfsHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateGitlfsHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateGitlfsHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *GitLfsRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *GitLfsRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryGitLfsHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetGitlfsHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetGitlfsHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *GitLfsRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *GitLfsRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGitLfsHostedModel)
 
@@ -81,12 +81,12 @@ func (f *GitLfsRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiC
 	stateModel := (state).(model.RepositoryGitLfsHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateGitlfsHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateGitlfsHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
-func (f *GitLfsRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *GitLfsRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetGitlfsHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetGitlfsHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/go.go
+++ b/internal/provider/repository/format/go.go
@@ -147,6 +147,7 @@ func (f *GoRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
 				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 			}

--- a/internal/provider/repository/format/go.go
+++ b/internal/provider/repository/format/go.go
@@ -61,27 +61,27 @@ func (f *GoRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // PROXY Go Format Functions
 // --------------------------------------------
-func (f *GoRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *GoRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGoProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateGoProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateGoProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *GoRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *GoRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryGoProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetGoProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetGoProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *GoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *GoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGoProxyModel)
 
@@ -89,13 +89,13 @@ func (f *GoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient
 	stateModel := (state).(model.RepositoryGoProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateGoProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateGoProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for NPM Proxy repositories
-func (f *GoRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *GoRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetGoProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetGoProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -201,27 +201,27 @@ func (f *GoRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(state a
 // --------------------------------------------
 // GORUP Go Format Functions
 // --------------------------------------------
-func (f *GoRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *GoRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGoGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateGoGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateGoGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *GoRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *GoRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryGoGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetGoGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetGoGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *GoRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *GoRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGoGroupModel)
 
@@ -229,7 +229,7 @@ func (f *GoRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient
 	stateModel := (state).(model.RepositoryGoGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateGoGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateGoGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *GoRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -263,9 +263,9 @@ func (f *GoRepositoryFormatGroup) UpdateStateFromApi(state any, api any) any {
 }
 
 // DoImportRequest implements the import functionality for Go Group repositories
-func (f *GoRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *GoRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetGoGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetGoGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -275,27 +275,27 @@ func (f *GoRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClie
 // --------------------------------------------
 // HOSTED Go Format Functions
 // --------------------------------------------
-func (f *GoRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *GoRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGoHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateGoHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateGoHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *GoRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *GoRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryGoHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetGoHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetGoHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *GoRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *GoRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGoHostedModel)
 
@@ -303,7 +303,7 @@ func (f *GoRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryGoHostedModel)
 
 	// Call API to Update
-	return apiClient.RepositoryManagementAPI.UpdateGoHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateGoHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *GoRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -337,9 +337,9 @@ func (f *GoRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any {
 }
 
 // DoImportRequest implements the import functionality for Go Hosted repositories
-func (f *GoRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *GoRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetGoHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetGoHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/go.go
+++ b/internal/provider/repository/format/go.go
@@ -65,8 +65,11 @@ func (f *GoRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.Rep
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryGoProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateGoProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateGoProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *GoRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -74,11 +77,11 @@ func (f *GoRepositoryFormatProxy) DoReadRequest(state any, apiClient common.Repo
 	stateModel := (state).(model.RepositoryGoProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetGoProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetGoProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *GoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -88,18 +91,21 @@ func (f *GoRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryGoProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateGoProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateGoProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for NPM Proxy repositories
 func (f *GoRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetGoProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetGoProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *GoRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -128,6 +134,26 @@ func (f *GoRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if state != nil {
 		stateModel = (state).(model.RepositoryGoProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.SimpleApiProxyRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/helm.go
+++ b/internal/provider/repository/format/helm.go
@@ -61,27 +61,27 @@ func (f *HelmRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted Helm Format Functions
 // --------------------------------------------
-func (f *HelmRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *HelmRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryHelmHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateHelmHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateHelmHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *HelmRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *HelmRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryHelmHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetHelmHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetHelmHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *HelmRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *HelmRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryHelmHostedModel)
 
@@ -89,7 +89,7 @@ func (f *HelmRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryHelmHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateHelmHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateHelmHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *HelmRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -123,9 +123,9 @@ func (f *HelmRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any 
 }
 
 // DoImportRequest implements the import functionality for Helm Hosted repositories
-func (f *HelmRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *HelmRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetHelmHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetHelmHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -135,27 +135,27 @@ func (f *HelmRepositoryFormatHosted) DoImportRequest(repositoryName string, apiC
 // --------------------------------------------
 // PROXY Helm Format Functions
 // --------------------------------------------
-func (f *HelmRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *HelmRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryHelmProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateHelmProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateHelmProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *HelmRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *HelmRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryHelmProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetHelmProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetHelmProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *HelmRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *HelmRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryHelmProxyModel)
 
@@ -163,13 +163,13 @@ func (f *HelmRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClie
 	stateModel := (state).(model.RepositoryHelmProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateHelmProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateHelmProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Helm Proxy repositories
-func (f *HelmRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *HelmRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetHelmProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetHelmProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -226,28 +226,28 @@ func (f *HelmRepositoryFormatProxy) SupportsRepositoryFirewall() bool {
 // --------------------------------------------
 // GROUP Helm Format Functions
 // --------------------------------------------
-func (f *HelmRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *HelmRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	planModel := (plan).(model.RepositoryHelmGroupModel)
-	return apiClient.RepositoryManagementAPI.CreateHelmGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateHelmGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *HelmRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *HelmRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	stateModel := (state).(model.RepositoryHelmGroupModel)
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetHelmGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetHelmGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *HelmRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *HelmRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	planModel := (plan).(model.RepositoryHelmGroupModel)
 	stateModel := (state).(model.RepositoryHelmGroupModel)
-	return apiClient.RepositoryManagementAPI.UpdateHelmGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateHelmGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
-func (f *HelmRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetHelmGroupRepository(ctx, repositoryName).Execute()
+func (f *HelmRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
+	apiResponse, httpResponse, err := apiClient.GetHelmGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/huggingface.go
+++ b/internal/provider/repository/format/huggingface.go
@@ -139,6 +139,7 @@ func (f *HuggingFaceRepositoryFormatProxy) UpdateStateFromApi(state any, api any
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
 				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 			}

--- a/internal/provider/repository/format/huggingface.go
+++ b/internal/provider/repository/format/huggingface.go
@@ -57,8 +57,11 @@ func (f *HuggingFaceRepositoryFormatProxy) DoCreateRequest(plan any, apiClient c
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryHuggingFaceProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateHuggingfaceProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateHuggingfaceProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *HuggingFaceRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -66,11 +69,11 @@ func (f *HuggingFaceRepositoryFormatProxy) DoReadRequest(state any, apiClient co
 	stateModel := (state).(model.RepositoryHuggingFaceProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetHuggingfaceProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetHuggingfaceProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *HuggingFaceRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -80,18 +83,21 @@ func (f *HuggingFaceRepositoryFormatProxy) DoUpdateRequest(plan any, state any, 
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryHuggingFaceProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateHuggingfaceProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateHuggingfaceProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for HuggingFace Proxy repositories
 func (f *HuggingFaceRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetHuggingfaceProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetHuggingfaceProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *HuggingFaceRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -120,6 +126,26 @@ func (f *HuggingFaceRepositoryFormatProxy) UpdateStateFromApi(state any, api any
 	if state != nil {
 		stateModel = (state).(model.RepositoryHuggingFaceProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.SimpleApiProxyRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/huggingface.go
+++ b/internal/provider/repository/format/huggingface.go
@@ -53,27 +53,27 @@ func (f *HuggingFaceRepositoryFormat) ResourceName(repoType RepositoryType) stri
 // --------------------------------------------
 // PROXY HuggingFace Format Functions
 // --------------------------------------------
-func (f *HuggingFaceRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *HuggingFaceRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryHuggingFaceProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateHuggingfaceProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateHuggingfaceProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *HuggingFaceRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *HuggingFaceRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryHuggingFaceProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetHuggingfaceProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetHuggingfaceProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *HuggingFaceRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *HuggingFaceRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryHuggingFaceProxyModel)
 
@@ -81,13 +81,13 @@ func (f *HuggingFaceRepositoryFormatProxy) DoUpdateRequest(plan any, state any, 
 	stateModel := (state).(model.RepositoryHuggingFaceProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateHuggingfaceProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateHuggingfaceProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for HuggingFace Proxy repositories
-func (f *HuggingFaceRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *HuggingFaceRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetHuggingfaceProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetHuggingfaceProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/maven.go
+++ b/internal/provider/repository/format/maven.go
@@ -64,27 +64,27 @@ func (f *MavenRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // HOSTED Maven Format Functions
 // --------------------------------------------
-func (f *MavenRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *MavenRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryMavenHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateMavenHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateMavenHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *MavenRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *MavenRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryMavenHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetMavenHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetMavenHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *MavenRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *MavenRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryMavenHostedModel)
 
@@ -92,13 +92,13 @@ func (f *MavenRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiCl
 	stateModel := (state).(model.RepositoryMavenHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateMavenHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateMavenHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Maven Hosted repositories
-func (f *MavenRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *MavenRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetMavenHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetMavenHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -140,27 +140,27 @@ func (f *MavenRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any
 // --------------------------------------------
 // PROXY Maven Format Functions
 // --------------------------------------------
-func (f *MavenRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *MavenRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryMavenProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateMavenProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateMavenProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *MavenRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *MavenRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryMavenProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetMavenProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetMavenProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *MavenRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *MavenRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryMavenProxyModel)
 
@@ -168,13 +168,13 @@ func (f *MavenRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryMavenProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateMavenProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateMavenProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Maven Proxy repositories
-func (f *MavenRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *MavenRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetMavenProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetMavenProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -282,27 +282,27 @@ func (f *MavenRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(stat
 // --------------------------------------------
 // GROUP Maven Format Functions
 // --------------------------------------------
-func (f *MavenRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *MavenRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryMavenGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateMavenGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateMavenGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *MavenRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *MavenRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryMavenGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetMavenGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetMavenGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *MavenRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *MavenRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryMavenGroupModel)
 
@@ -310,13 +310,13 @@ func (f *MavenRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryMavenGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateMavenGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateMavenGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Maven Group repositories
-func (f *MavenRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *MavenRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetMavenGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetMavenGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -369,13 +369,13 @@ func mavenSchemaAttributes() map[string]tfschema.Attribute {
 		"maven": schema.ResourceRequiredSingleNestedAttribute(
 			"Maven specific configuration for this Repository",
 			map[string]tfschema.Attribute{
-				"version_policy": schema.ResourceOptionalStringEnum(
+				"version_policy": schema.ResourceRequiredStringEnum(
 					"What type of artifacts does this repository store?",
 					common.MAVEN_VERSION_POLICY_RELEASE,
 					common.MAVEN_VERSION_POLICY_SNAPSHOT,
 					common.MAVEN_VERSION_POLICY_MIXED,
 				),
-				"layout_policy": schema.ResourceOptionalStringEnum(
+				"layout_policy": schema.ResourceRequiredStringEnum(
 					"Validate that all paths are maven artifact or metadata paths",
 					common.MAVEN_LAYOUT_STRICT,
 					common.MAVEN_LAYOUT_PERMISSIVE,

--- a/internal/provider/repository/format/npm.go
+++ b/internal/provider/repository/format/npm.go
@@ -225,6 +225,7 @@ func (f *NpmRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineWithPccsModelWithDefaults()
 				}
 				enabled, quarantine, pccsEnabled := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 				stateModel.FirewallAuditAndQuarantine.PccsEnabled = types.BoolValue(pccsEnabled)

--- a/internal/provider/repository/format/npm.go
+++ b/internal/provider/repository/format/npm.go
@@ -61,27 +61,27 @@ func (f *NpmRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted NPM Format Functions
 // --------------------------------------------
-func (f *NpmRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NpmRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNpmHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateNpmHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateNpmHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *NpmRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NpmRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryNpmHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNpmHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNpmHostedRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *NpmRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NpmRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNpmHostedModel)
 
@@ -89,7 +89,7 @@ func (f *NpmRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClie
 	stateModel := (state).(model.RepositoryNpmHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateNpmHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateNpmHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *NpmRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -124,9 +124,9 @@ func (f *NpmRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any {
 }
 
 // DoImportRequest implements the import functionality for NPM Hosted repositories
-func (f *NpmRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NpmRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNpmHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNpmHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -136,15 +136,15 @@ func (f *NpmRepositoryFormatHosted) DoImportRequest(repositoryName string, apiCl
 // --------------------------------------------
 // PROXY NPM Format Functions
 // --------------------------------------------
-func (f *NpmRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NpmRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNpmProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateNpmProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateNpmProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *NpmRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NpmRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryNpmProxyModel)
 
@@ -152,14 +152,14 @@ func (f *NpmRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyper
 	repoName := stateModel.Name.ValueString()
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNpmProxyRepository(ctx, repoName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNpmProxyRepository(ctx, repoName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *NpmRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NpmRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNpmProxyModel)
 
@@ -167,13 +167,13 @@ func (f *NpmRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryNpmProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateNpmProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateNpmProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for NPM Proxy repositories
-func (f *NpmRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NpmRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNpmProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNpmProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -297,27 +297,27 @@ func (f *NpmRepositoryFormatProxy) GetRepositoryFirewallPccsEnabled(state any) b
 // --------------------------------------------
 // GORUP NPM Format Functions
 // --------------------------------------------
-func (f *NpmRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NpmRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNpmGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateNpmGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateNpmGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *NpmRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NpmRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryNpmGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNpmGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNpmGroupRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *NpmRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NpmRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNpmGroupModel)
 
@@ -325,7 +325,7 @@ func (f *NpmRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryNpmGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateNpmGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateNpmGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *NpmRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -359,9 +359,9 @@ func (f *NpmRepositoryFormatGroup) UpdateStateFromApi(state any, api any) any {
 }
 
 // DoImportRequest implements the import functionality for NPM Group repositories
-func (f *NpmRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NpmRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNpmGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNpmGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/npm.go
+++ b/internal/provider/repository/format/npm.go
@@ -140,8 +140,11 @@ func (f *NpmRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.Re
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNpmProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateNpmProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateNpmProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *NpmRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -152,11 +155,11 @@ func (f *NpmRepositoryFormatProxy) DoReadRequest(state any, apiClient common.Rep
 	repoName := stateModel.Name.ValueString()
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetNpmProxyRepository(ctx, repoName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetNpmProxyRepository(ctx, repoName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *NpmRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -166,18 +169,21 @@ func (f *NpmRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClien
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryNpmProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateNpmProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateNpmProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for NPM Proxy repositories
 func (f *NpmRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetNpmProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetNpmProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *NpmRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -206,6 +212,27 @@ func (f *NpmRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if state != nil {
 		stateModel = (state).(model.RepositoryNpmProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.NpmProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineWithPccsModelWithDefaults()
+				}
+				enabled, quarantine, pccsEnabled := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+				stateModel.FirewallAuditAndQuarantine.PccsEnabled = types.BoolValue(pccsEnabled)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.NpmProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/nuget.go
+++ b/internal/provider/repository/format/nuget.go
@@ -64,27 +64,27 @@ func (f *NugetRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted Nuget Format Functions
 // --------------------------------------------
-func (f *NugetRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NugetRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNugetHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateNugetHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateNugetHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *NugetRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NugetRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryNugetHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNugetHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNugetHostedRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *NugetRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NugetRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNugetHostedModel)
 
@@ -92,7 +92,7 @@ func (f *NugetRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiCl
 	stateModel := (state).(model.RepositoryNugetHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateNugetHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateNugetHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *NugetRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -127,9 +127,9 @@ func (f *NugetRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any
 }
 
 // DoImportRequest implements the import functionality for NuGet Hosted repositories
-func (f *NugetRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NugetRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNugetHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNugetHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -139,27 +139,27 @@ func (f *NugetRepositoryFormatHosted) DoImportRequest(repositoryName string, api
 // --------------------------------------------
 // PROXY Nuget Format Functions
 // --------------------------------------------
-func (f *NugetRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NugetRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNugetProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateNugetProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateNugetProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *NugetRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NugetRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryNugetProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNugetProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNugetProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *NugetRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NugetRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNugetProxyModel)
 
@@ -167,13 +167,13 @@ func (f *NugetRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryNugetProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateNugetProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateNugetProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for NuGet Proxy repositories
-func (f *NugetRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NugetRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNugetProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNugetProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -281,27 +281,27 @@ func (f *NugetRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(stat
 // --------------------------------------------
 // GROUP Nuget Format Functions
 // --------------------------------------------
-func (f *NugetRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NugetRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNugetGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateNugetGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateNugetGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *NugetRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NugetRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryNugetGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNugetGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNugetGroupRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *NugetRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *NugetRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNugetGroupModel)
 
@@ -309,7 +309,7 @@ func (f *NugetRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryNugetGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateNugetGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateNugetGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *NugetRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -343,9 +343,9 @@ func (f *NugetRepositoryFormatGroup) UpdateStateFromApi(state any, api any) any 
 }
 
 // DoImportRequest implements the import functionality for NuGet Group repositories
-func (f *NugetRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *NugetRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetNugetGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetNugetGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/p2.go
+++ b/internal/provider/repository/format/p2.go
@@ -53,27 +53,27 @@ func (f *P2RepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // PROXY P2 Format Functions
 // --------------------------------------------
-func (f *P2RepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *P2RepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryP2ProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateP2ProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateP2ProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *P2RepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *P2RepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryP2ProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetP2ProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetP2ProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *P2RepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *P2RepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryP2ProxyModel)
 
@@ -81,13 +81,13 @@ func (f *P2RepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient
 	stateModel := (state).(model.RepositoryP2ProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateP2ProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateP2ProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for P2 Proxy repositories
-func (f *P2RepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *P2RepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetP2ProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetP2ProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/proxy.go
+++ b/internal/provider/repository/format/proxy.go
@@ -34,6 +34,59 @@ import (
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 )
 
+// FirewallModeFromFlags derives the inline `firewall.mode` value (NXRM 3.94+) from the
+// Terraform schema flags stored in `repository_firewall`.
+func FirewallModeFromFlags(hasConfig, enabled, quarantine, pccsEnabled bool) common.FirewallMode {
+	if !hasConfig || !enabled {
+		return common.FirewallModeDisabled
+	}
+	if pccsEnabled {
+		return common.FirewallModePccs
+	}
+	if quarantine {
+		return common.FirewallModeQuarantine
+	}
+	return common.FirewallModeAudit
+}
+
+// FirewallFlagsFromMode derives the `repository_firewall` schema flags from the inline
+// `firewall.mode` value (NXRM 3.94+).
+func FirewallFlagsFromMode(mode common.FirewallMode) (enabled, quarantine, pccsEnabled bool) {
+	switch mode {
+	case common.FirewallModeAudit:
+		return true, false, false
+	case common.FirewallModeQuarantine:
+		return true, true, false
+	case common.FirewallModePccs:
+		return true, false, true
+	default:
+		return false, false, false
+	}
+}
+
+// ComputeFirewallMode derives the inline `firewall.mode` value (NXRM 3.94+) for a proxy
+// repository's plan/state model. It only asks for quarantine/pccs flags when a
+// `repository_firewall` block is actually present, since some formats' getters for those
+// flags assume a non-nil block.
+func ComputeFirewallMode(f RepositoryFormat, state any) common.FirewallMode {
+	hasConfig := f.HasFirewallConfig(state)
+	enabled := f.GetRepositoryFirewallEnabled(state)
+	var quarantine, pccsEnabled bool
+	if hasConfig {
+		quarantine = f.GetRepositoryFirewallQuarantineEnabled(state)
+		pccsEnabled = f.GetRepositoryFirewallPccsEnabled(state)
+	}
+	return FirewallModeFromFlags(hasConfig, enabled, quarantine, pccsEnabled)
+}
+
+// ProxyApiResponseWithFirewall carries a proxy repository API response together with its
+// inline `firewall.mode` value (NXRM 3.94+), threading the mode through DoReadRequest/
+// DoImportRequest to UpdateStateFromApi without changing the RepositoryFormat interface.
+type ProxyApiResponseWithFirewall struct {
+	Repository   any
+	FirewallMode *common.FirewallMode
+}
+
 func commonProxySchemaAttributes(supportsRepositoryFirewall, supportsPccs bool) map[string]tfschema.Attribute {
 	thisAttr := map[string]tfschema.Attribute{
 		"proxy": schema.ResourceRequiredSingleNestedAttribute(

--- a/internal/provider/repository/format/proxy_test.go
+++ b/internal/provider/repository/format/proxy_test.go
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"fmt"
+	"terraform-provider-sonatyperepo/internal/provider/common"
+	"terraform-provider-sonatyperepo/internal/provider/model"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type firewallModeFromFlagsTestCase struct {
+	description    string
+	hasConfig      bool
+	enabled        bool
+	quarantine     bool
+	pccsEnabled    bool
+	expectedResult common.FirewallMode
+}
+
+func TestFirewallModeFromFlags(t *testing.T) {
+	testCases := []firewallModeFromFlagsTestCase{
+		{
+			"No repository_firewall block",
+			false, false, false, false,
+			common.FirewallModeDisabled,
+		},
+		{
+			"repository_firewall present but disabled",
+			true, false, false, false,
+			common.FirewallModeDisabled,
+		},
+		{
+			"Enabled, no quarantine, no pccs -> Audit",
+			true, true, false, false,
+			common.FirewallModeAudit,
+		},
+		{
+			"Enabled with quarantine -> Quarantine",
+			true, true, true, false,
+			common.FirewallModeQuarantine,
+		},
+		{
+			"Enabled with pccs -> Pccs",
+			true, true, false, true,
+			common.FirewallModePccs,
+		},
+		{
+			"Enabled with both quarantine and pccs -> Pccs takes precedence",
+			true, true, true, true,
+			common.FirewallModePccs,
+		},
+	}
+
+	for i, testCase := range testCases {
+		assert.Equal(
+			t,
+			testCase.expectedResult,
+			FirewallModeFromFlags(testCase.hasConfig, testCase.enabled, testCase.quarantine, testCase.pccsEnabled),
+			fmt.Sprintf("%d: %s - FirewallMode not as expected", i, testCase.description),
+		)
+	}
+}
+
+type firewallFlagsFromModeTestCase struct {
+	mode               common.FirewallMode
+	expectedEnabled    bool
+	expectedQuarantine bool
+	expectedPccs       bool
+}
+
+func TestFirewallFlagsFromMode(t *testing.T) {
+	testCases := []firewallFlagsFromModeTestCase{
+		{common.FirewallModeDisabled, false, false, false},
+		{common.FirewallModeAudit, true, false, false},
+		{common.FirewallModeQuarantine, true, true, false},
+		{common.FirewallModePccs, true, false, true},
+	}
+
+	for i, testCase := range testCases {
+		enabled, quarantine, pccsEnabled := FirewallFlagsFromMode(testCase.mode)
+		assert.Equal(t, testCase.expectedEnabled, enabled, fmt.Sprintf("%d: %s - enabled not as expected", i, testCase.mode))
+		assert.Equal(t, testCase.expectedQuarantine, quarantine, fmt.Sprintf("%d: %s - quarantine not as expected", i, testCase.mode))
+		assert.Equal(t, testCase.expectedPccs, pccsEnabled, fmt.Sprintf("%d: %s - pccsEnabled not as expected", i, testCase.mode))
+	}
+}
+
+type computeFirewallModeTestCase struct {
+	description    string
+	firewall       *model.FirewallAuditAndQuarantineWithPccsModel
+	expectedResult common.FirewallMode
+}
+
+func TestComputeFirewallMode(t *testing.T) {
+	testCases := []computeFirewallModeTestCase{
+		{
+			"No repository_firewall block",
+			nil,
+			common.FirewallModeDisabled,
+		},
+		{
+			"repository_firewall present but disabled",
+			&model.FirewallAuditAndQuarantineWithPccsModel{
+				FirewallAuditAndQuarantineModel: model.FirewallAuditAndQuarantineModel{
+					Enabled:    types.BoolValue(false),
+					Quarantine: types.BoolValue(false),
+				},
+				PccsEnabled: types.BoolValue(false),
+			},
+			common.FirewallModeDisabled,
+		},
+		{
+			"Enabled, no quarantine, no pccs -> Audit",
+			&model.FirewallAuditAndQuarantineWithPccsModel{
+				FirewallAuditAndQuarantineModel: model.FirewallAuditAndQuarantineModel{
+					Enabled:    types.BoolValue(true),
+					Quarantine: types.BoolValue(false),
+				},
+				PccsEnabled: types.BoolValue(false),
+			},
+			common.FirewallModeAudit,
+		},
+		{
+			"Enabled with quarantine -> Quarantine",
+			&model.FirewallAuditAndQuarantineWithPccsModel{
+				FirewallAuditAndQuarantineModel: model.FirewallAuditAndQuarantineModel{
+					Enabled:    types.BoolValue(true),
+					Quarantine: types.BoolValue(true),
+				},
+				PccsEnabled: types.BoolValue(false),
+			},
+			common.FirewallModeQuarantine,
+		},
+		{
+			"Enabled with pccs -> Pccs",
+			&model.FirewallAuditAndQuarantineWithPccsModel{
+				FirewallAuditAndQuarantineModel: model.FirewallAuditAndQuarantineModel{
+					Enabled:    types.BoolValue(true),
+					Quarantine: types.BoolValue(false),
+				},
+				PccsEnabled: types.BoolValue(true),
+			},
+			common.FirewallModePccs,
+		},
+	}
+
+	f := &NpmRepositoryFormatProxy{}
+
+	for i, testCase := range testCases {
+		stateModel := model.RepositoryNpmProxyModel{
+			FirewallAuditAndQuarantine: testCase.firewall,
+		}
+		assert.Equal(
+			t,
+			testCase.expectedResult,
+			ComputeFirewallMode(f, stateModel),
+			fmt.Sprintf("%d: %s - FirewallMode not as expected", i, testCase.description),
+		)
+	}
+}

--- a/internal/provider/repository/format/pypi.go
+++ b/internal/provider/repository/format/pypi.go
@@ -139,8 +139,11 @@ func (f *PyPiRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.R
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryPyPiProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreatePypiProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreatePypiProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *PyPiRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -148,11 +151,11 @@ func (f *PyPiRepositoryFormatProxy) DoReadRequest(state any, apiClient common.Re
 	stateModel := (state).(model.RepositoryPyPiProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetPypiProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetPypiProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *PyPiRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -162,18 +165,21 @@ func (f *PyPiRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClie
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryPyPiProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdatePypiProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdatePypiProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for PyPI Proxy repositories
 func (f *PyPiRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetPypiProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetPypiProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *PyPiRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -202,6 +208,27 @@ func (f *PyPiRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if state != nil {
 		stateModel = (state).(model.RepositoryPyPiProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.PyPiProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineWithPccsModelWithDefaults()
+				}
+				enabled, quarantine, pccsEnabled := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+				stateModel.FirewallAuditAndQuarantine.PccsEnabled = types.BoolValue(pccsEnabled)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.PyPiProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/pypi.go
+++ b/internal/provider/repository/format/pypi.go
@@ -61,27 +61,27 @@ func (f *PyPiRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted PyPi Format Functions
 // --------------------------------------------
-func (f *PyPiRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *PyPiRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryPyPiHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreatePypiHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreatePypiHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *PyPiRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *PyPiRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryPyPiHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetPypiHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetPypiHostedRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *PyPiRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *PyPiRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryPyPiHostedModel)
 
@@ -89,7 +89,7 @@ func (f *PyPiRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositoryPyPiHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdatePypiHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdatePypiHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *PyPiRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -123,9 +123,9 @@ func (f *PyPiRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any 
 }
 
 // DoImportRequest implements the import functionality for PyPI Hosted repositories
-func (f *PyPiRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *PyPiRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetPypiHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetPypiHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -135,27 +135,27 @@ func (f *PyPiRepositoryFormatHosted) DoImportRequest(repositoryName string, apiC
 // --------------------------------------------
 // PROXY PyPi Format Functions
 // --------------------------------------------
-func (f *PyPiRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *PyPiRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryPyPiProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreatePypiProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreatePypiProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *PyPiRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *PyPiRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryPyPiProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetPypiProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetPypiProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *PyPiRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *PyPiRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryPyPiProxyModel)
 
@@ -163,13 +163,13 @@ func (f *PyPiRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClie
 	stateModel := (state).(model.RepositoryPyPiProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdatePypiProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdatePypiProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for PyPI Proxy repositories
-func (f *PyPiRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *PyPiRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetPypiProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetPypiProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -293,27 +293,27 @@ func (f *PyPiRepositoryFormatProxy) GetRepositoryFirewallPccsEnabled(state any) 
 // --------------------------------------------
 // GORUP PyPi Format Functions
 // --------------------------------------------
-func (f *PyPiRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *PyPiRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryPyPiGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreatePypiGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreatePypiGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *PyPiRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *PyPiRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryPyPiGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetPypiGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetPypiGroupRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *PyPiRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *PyPiRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryPyPiGroupModel)
 
@@ -321,7 +321,7 @@ func (f *PyPiRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClie
 	stateModel := (state).(model.RepositoryPyPiGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdatePypiGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdatePypiGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *PyPiRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -355,9 +355,9 @@ func (f *PyPiRepositoryFormatGroup) UpdateStateFromApi(state any, api any) any {
 }
 
 // DoImportRequest implements the import functionality for PyPI Group repositories
-func (f *PyPiRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *PyPiRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetPypiGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetPypiGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/pypi.go
+++ b/internal/provider/repository/format/pypi.go
@@ -221,6 +221,7 @@ func (f *PyPiRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineWithPccsModelWithDefaults()
 				}
 				enabled, quarantine, pccsEnabled := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 				stateModel.FirewallAuditAndQuarantine.PccsEnabled = types.BoolValue(pccsEnabled)

--- a/internal/provider/repository/format/r.go
+++ b/internal/provider/repository/format/r.go
@@ -61,27 +61,27 @@ func (f *RRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted R(CRAN) Format Functions
 // --------------------------------------------
-func (f *RRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryRHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRHostedModel)
 
@@ -89,12 +89,12 @@ func (f *RRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient
 	stateModel := (state).(model.RepositoryRHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
-func (f *RRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -134,27 +134,27 @@ func (f *RRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any {
 // --------------------------------------------
 // PROXY R(CRAN) Format Functions
 // --------------------------------------------
-func (f *RRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorRProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositorRProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorRProxyModel)
 
@@ -162,12 +162,12 @@ func (f *RRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient 
 	stateModel := (state).(model.RepositorRProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
-func (f *RRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -272,27 +272,27 @@ func (f *RRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(state an
 // --------------------------------------------
 // GORUP R(CRAN) Format Functions
 // --------------------------------------------
-func (f *RRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryRGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRGroupModel)
 
@@ -300,7 +300,7 @@ func (f *RRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient 
 	stateModel := (state).(model.RepositoryRGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *RRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {

--- a/internal/provider/repository/format/r.go
+++ b/internal/provider/repository/format/r.go
@@ -138,8 +138,11 @@ func (f *RRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.Repo
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorRProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateRProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateRProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *RRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -147,11 +150,11 @@ func (f *RRepositoryFormatProxy) DoReadRequest(state any, apiClient common.Repos
 	stateModel := (state).(model.RepositorRProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetRProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetRProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *RRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -161,17 +164,20 @@ func (f *RRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient 
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositorRProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateRProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateRProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 func (f *RRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetRProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetRProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *RRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -200,6 +206,26 @@ func (f *RRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if state != nil {
 		stateModel = (state).(model.RepositorRProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.SimpleApiProxyRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/r.go
+++ b/internal/provider/repository/format/r.go
@@ -219,6 +219,7 @@ func (f *RRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
 				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
 			}

--- a/internal/provider/repository/format/raw.go
+++ b/internal/provider/repository/format/raw.go
@@ -64,27 +64,27 @@ func (f *RawRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted Raw Format Functions
 // --------------------------------------------
-func (f *RawRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RawRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRawHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRawHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRawHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RawRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RawRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryRawHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRawHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRawHostedRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RawRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RawRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRawHostedModel)
 
@@ -92,13 +92,13 @@ func (f *RawRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClie
 	stateModel := (state).(model.RepositoryRawHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRawHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRawHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Raw Hosted repositories
-func (f *RawRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RawRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRawHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRawHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -140,27 +140,27 @@ func (f *RawRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any {
 // --------------------------------------------
 // PROXY Raw Format Functions
 // --------------------------------------------
-func (f *RawRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RawRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRawProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRawProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRawProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RawRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RawRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryRawProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRawProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRawProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RawRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RawRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRawProxyModel)
 
@@ -168,13 +168,13 @@ func (f *RawRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryRawProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRawProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRawProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Raw Proxy repositories
-func (f *RawRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RawRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRawProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRawProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -282,27 +282,27 @@ func (f *RawRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(state 
 // --------------------------------------------
 // GORUP Raw Format Functions
 // --------------------------------------------
-func (f *RawRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RawRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRawGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRawGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRawGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RawRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RawRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryRawGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRawGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRawGroupRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RawRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RawRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRawGroupModel)
 
@@ -310,7 +310,7 @@ func (f *RawRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryRawGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRawGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRawGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *RawRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -346,9 +346,9 @@ func (f *RawRepositoryFormatGroup) UpdateStateFromApi(state any, api any) any {
 }
 
 // DoImportRequest implements the import functionality for Raw Group repositories
-func (f *RawRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RawRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRawGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRawGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/ruby_gems.go
+++ b/internal/provider/repository/format/ruby_gems.go
@@ -61,27 +61,27 @@ func (f *RubyGemsRepositoryFormat) ResourceName(repoType RepositoryType) string 
 // --------------------------------------------
 // Hosted RubyGems Format Functions
 // --------------------------------------------
-func (f *RubyGemsRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RubyGemsRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRubyGemsHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRubygemsHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRubygemsHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RubyGemsRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RubyGemsRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryRubyGemsHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRubygemsHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRubygemsHostedRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RubyGemsRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RubyGemsRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRubyGemsHostedModel)
 
@@ -89,7 +89,7 @@ func (f *RubyGemsRepositoryFormatHosted) DoUpdateRequest(plan any, state any, ap
 	stateModel := (state).(model.RepositoryRubyGemsHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRubygemsHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRubygemsHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *RubyGemsRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -123,9 +123,9 @@ func (f *RubyGemsRepositoryFormatHosted) UpdateStateFromApi(state any, api any) 
 }
 
 // DoImportRequest implements the import functionality for RubyGems Hosted repositories
-func (f *RubyGemsRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RubyGemsRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRubygemsHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRubygemsHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -135,27 +135,27 @@ func (f *RubyGemsRepositoryFormatHosted) DoImportRequest(repositoryName string, 
 // --------------------------------------------
 // PROXY RubyGems Format Functions
 // --------------------------------------------
-func (f *RubyGemsRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RubyGemsRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorRubyGemsProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRubygemsProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRubygemsProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RubyGemsRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RubyGemsRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositorRubyGemsProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRubygemsProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRubygemsProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RubyGemsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RubyGemsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorRubyGemsProxyModel)
 
@@ -163,13 +163,13 @@ func (f *RubyGemsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, api
 	stateModel := (state).(model.RepositorRubyGemsProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRubygemsProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRubygemsProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for RubyGems Proxy repositories
-func (f *RubyGemsRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RubyGemsRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRubygemsProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRubygemsProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -275,27 +275,27 @@ func (f *RubyGemsRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(s
 // --------------------------------------------
 // GORUP RubyGems Format Functions
 // --------------------------------------------
-func (f *RubyGemsRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RubyGemsRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRubyGemsGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateRubygemsGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateRubygemsGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *RubyGemsRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RubyGemsRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryRubyGemsGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRubygemsGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRubygemsGroupRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *RubyGemsRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *RubyGemsRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRubyGemsGroupModel)
 
@@ -303,7 +303,7 @@ func (f *RubyGemsRepositoryFormatGroup) DoUpdateRequest(plan any, state any, api
 	stateModel := (state).(model.RepositoryRubyGemsGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateRubygemsGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateRubygemsGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *RubyGemsRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -337,9 +337,9 @@ func (f *RubyGemsRepositoryFormatGroup) UpdateStateFromApi(state any, api any) a
 }
 
 // DoImportRequest implements the import functionality for RubyGems Group repositories
-func (f *RubyGemsRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *RubyGemsRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetRubygemsGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetRubygemsGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/swift.go
+++ b/internal/provider/repository/format/swift.go
@@ -59,27 +59,27 @@ func (f *SwiftRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // PROXY Swift Format Functions
 // --------------------------------------------
-func (f *SwiftRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *SwiftRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorySwiftProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateSwiftProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateSwiftProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *SwiftRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *SwiftRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositorySwiftProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetSwiftProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetSwiftProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *SwiftRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *SwiftRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorySwiftProxyModel)
 
@@ -87,13 +87,13 @@ func (f *SwiftRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositorySwiftProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateSwiftProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateSwiftProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for HuggingFace Proxy repositories
-func (f *SwiftRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *SwiftRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetSwiftProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetSwiftProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -151,27 +151,27 @@ func (f *SwiftRepositoryFormatProxy) SupportsRepositoryFirewall() bool {
 // --------------------------------------------
 // Group Swift Format Functions
 // --------------------------------------------
-func (f *SwiftRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *SwiftRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorySwiftGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateSwiftGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateSwiftGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *SwiftRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *SwiftRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositorySwiftGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetSwiftGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetSwiftGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *SwiftRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *SwiftRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorySwiftGroupModel)
 
@@ -179,7 +179,7 @@ func (f *SwiftRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiCli
 	stateModel := (state).(model.RepositorySwiftGroupModel)
 
 	// Call API to Update
-	return apiClient.RepositoryManagementAPI.UpdateSwiftGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateSwiftGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *SwiftRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -213,9 +213,9 @@ func (f *SwiftRepositoryFormatGroup) UpdateStateFromApi(state any, api any) any 
 }
 
 // DoImportRequest implements the import functionality for Swift Group repositories
-func (f *SwiftRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *SwiftRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetSwiftGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetSwiftGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/terraform.go
+++ b/internal/provider/repository/format/terraform.go
@@ -64,27 +64,27 @@ func (f *TerraformRepositoryFormat) ResourceName(repoType RepositoryType) string
 // --------------------------------------------
 // PROXY Terraform Format Functions
 // --------------------------------------------
-func (f *TerraformRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *TerraformRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryTerraformProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateTerraformProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateTerraformProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *TerraformRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *TerraformRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryTerraformProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetTerraformProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetTerraformProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *TerraformRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *TerraformRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryTerraformProxyModel)
 
@@ -92,13 +92,13 @@ func (f *TerraformRepositoryFormatProxy) DoUpdateRequest(plan any, state any, ap
 	stateModel := (state).(model.RepositoryTerraformProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateTerraformProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateTerraformProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for HuggingFace Proxy repositories
-func (f *TerraformRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *TerraformRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetTerraformProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetTerraformProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -156,27 +156,27 @@ func (f *TerraformRepositoryFormatProxy) SupportsRepositoryFirewall() bool {
 // --------------------------------------------
 // HOSTED Terraform Format Functions
 // --------------------------------------------
-func (f *TerraformRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *TerraformRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryTerraformHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateTerraformHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateTerraformHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *TerraformRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *TerraformRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryTerraformHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetTerraformHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetTerraformHostedRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *TerraformRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *TerraformRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryTerraformHostedModel)
 
@@ -184,13 +184,13 @@ func (f *TerraformRepositoryFormatHosted) DoUpdateRequest(plan any, state any, a
 	stateModel := (state).(model.RepositoryTerraformHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateTerraformHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateTerraformHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for HuggingFace Proxy repositories
-func (f *TerraformRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *TerraformRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetTerraformHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetTerraformHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -230,27 +230,27 @@ func (f *TerraformRepositoryFormatHosted) UpdateStateFromApi(state, api any) any
 // --------------------------------------------
 // GROUP Terraform Format Functions
 // --------------------------------------------
-func (f *TerraformRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *TerraformRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryTerraformGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateTerraformGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateTerraformGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *TerraformRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *TerraformRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryTerraformGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetTerraformGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetTerraformGroupRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *TerraformRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *TerraformRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryTerraformGroupModel)
 
@@ -258,13 +258,13 @@ func (f *TerraformRepositoryFormatGroup) DoUpdateRequest(plan any, state any, ap
 	stateModel := (state).(model.RepositoryTerraformGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateTerraformGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateTerraformGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for Maven Group repositories
-func (f *TerraformRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *TerraformRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetTerraformGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetTerraformGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}

--- a/internal/provider/repository/format/yum.go
+++ b/internal/provider/repository/format/yum.go
@@ -65,27 +65,27 @@ func (f *YumRepositoryFormat) ResourceName(repoType RepositoryType) string {
 // --------------------------------------------
 // Hosted YUM Format Functions
 // --------------------------------------------
-func (f *YumRepositoryFormatHosted) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *YumRepositoryFormatHosted) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryYumHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateYumHostedRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateYumHostedRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *YumRepositoryFormatHosted) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *YumRepositoryFormatHosted) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryYumHostedModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetYumHostedRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetYumHostedRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *YumRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *YumRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryYumHostedModel)
 
@@ -93,7 +93,7 @@ func (f *YumRepositoryFormatHosted) DoUpdateRequest(plan any, state any, apiClie
 	stateModel := (state).(model.RepositoryYumHostedModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateYumHostedRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateYumHostedRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *YumRepositoryFormatHosted) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -129,9 +129,9 @@ func (f *YumRepositoryFormatHosted) UpdateStateFromApi(state any, api any) any {
 }
 
 // DoImportRequest implements the import functionality for YUM Hosted repositories
-func (f *YumRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *YumRepositoryFormatHosted) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetYumHostedRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetYumHostedRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -141,27 +141,27 @@ func (f *YumRepositoryFormatHosted) DoImportRequest(repositoryName string, apiCl
 // --------------------------------------------
 // PROXY YUM Format Functions
 // --------------------------------------------
-func (f *YumRepositoryFormatProxy) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *YumRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryYumProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateYumProxyRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateYumProxyRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *YumRepositoryFormatProxy) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *YumRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryYumProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetYumProxyRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetYumProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *YumRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *YumRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryYumProxyModel)
 
@@ -169,13 +169,13 @@ func (f *YumRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryYumProxyModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateYumProxyRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateYumProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 // DoImportRequest implements the import functionality for YUM Proxy repositories
-func (f *YumRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *YumRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetYumProxyRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetYumProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -283,27 +283,27 @@ func (f *YumRepositoryFormatProxy) GetRepositoryFirewallQuarantineEnabled(state 
 // --------------------------------------------
 // GORUP YUM Format Functions
 // --------------------------------------------
-func (f *YumRepositoryFormatGroup) DoCreateRequest(plan any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *YumRepositoryFormatGroup) DoCreateRequest(plan any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryYumGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.CreateYumGroupRepository(ctx).Body(planModel.ToApiCreateModel()).Execute()
+	return apiClient.CreateYumGroupRepository(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *YumRepositoryFormatGroup) DoReadRequest(state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *YumRepositoryFormatGroup) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryYumGroupModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetYumGroupRepository(ctx, stateModel.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := apiClient.GetYumGroupRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
 	return *apiResponse, httpResponse, err
 }
 
-func (f *YumRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient *sonatyperepo.APIClient, ctx context.Context) (*http.Response, error) {
+func (f *YumRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryYumGroupModel)
 
@@ -311,7 +311,7 @@ func (f *YumRepositoryFormatGroup) DoUpdateRequest(plan any, state any, apiClien
 	stateModel := (state).(model.RepositoryYumGroupModel)
 
 	// Call API to Create
-	return apiClient.RepositoryManagementAPI.UpdateYumGroupRepository(ctx, stateModel.Name.ValueString()).Body(planModel.ToApiUpdateModel()).Execute()
+	return apiClient.UpdateYumGroupRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *YumRepositoryFormatGroup) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -357,9 +357,9 @@ func (f *YumRepositoryFormatGroup) UpdateStateFromApi(state any, api any) any {
 }
 
 // DoImportRequest implements the import functionality for YUM Group repositories
-func (f *YumRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient *sonatyperepo.APIClient, ctx context.Context) (any, *http.Response, error) {
+func (f *YumRepositoryFormatGroup) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.RepositoryManagementAPI.GetYumGroupRepository(ctx, repositoryName).Execute()
+	apiResponse, httpResponse, err := apiClient.GetYumGroupRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
@@ -375,8 +375,9 @@ func yumSchemaAttributes(isHosted bool) map[string]tfschema.Attribute {
 			"yum": schema.ResourceRequiredSingleNestedAttribute(
 				"YUM specific configuration for this Repository",
 				map[string]tfschema.Attribute{
-					"deploy_policy": schema.ResourceOptionalStringEnum(
+					"deploy_policy": schema.ResourceStringEnumWithDefault(
 						"Validate that all paths are RPMs or yum metadata.",
+						common.DEPLOY_POLICY_STRICT,
 						common.DEPLOY_POLICY_PERMISSIVE,
 						common.DEPLOY_POLICY_STRICT,
 					),

--- a/internal/provider/repository/repositories_data_source.go
+++ b/internal/provider/repository/repositories_data_source.go
@@ -29,8 +29,6 @@ import (
 
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -78,13 +76,9 @@ func (d *repositoriesDataSource) Schema(_ context.Context, req datasource.Schema
 func (d *repositoriesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state model.RepositoriesModel
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	repositories, httpResponse, err := d.Client.RepositoryManagementAPI.GetAllRepositories(ctx).Execute()
+	repositories, httpResponse, err := d.Services.Repository.ListRepositories(ctx)
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable to read Repositories",

--- a/internal/provider/repository/repository_common.go
+++ b/internal/provider/repository/repository_common.go
@@ -82,18 +82,23 @@ func (r *repositoryResource) Create(ctx context.Context, req resource.CreateRequ
 	// Setup context with auth
 	ctx = r.AuthContext(ctx)
 
+	// Build an API-safe copy of the plan that omits http_client.connection when the
+	// user's config left it unset, so we don't send computed defaults to NXRM as if
+	// they were explicitly configured. State is still populated from the original plan.
+	apiPlan := suppressUnconfiguredConnectionFromConfig(ctx, plan, req.Config)
+
 	// Verify IQ connection if needed for firewall
-	if r.usesCapabilityBasedFirewall() && !r.verifyIQConnectionIfNeeded(ctx, plan, &resp.Diagnostics) {
+	if r.usesCapabilityBasedFirewall() && !r.verifyIQConnectionIfNeeded(ctx, apiPlan, &resp.Diagnostics) {
 		return
 	}
 
 	// Create the repository
-	if !r.createRepository(ctx, plan, resp) {
+	if !r.createRepository(ctx, apiPlan, resp) {
 		return
 	}
 
 	// Fetch complete data
-	apiResponse, ok := r.readCreatedRepository(ctx, plan, &resp.Diagnostics, &resp.State)
+	apiResponse, ok := r.readCreatedRepository(ctx, apiPlan, &resp.Diagnostics, &resp.State)
 	if !ok {
 		return
 	}
@@ -106,7 +111,7 @@ func (r *repositoryResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Configure firewall if needed
 	if r.usesCapabilityBasedFirewall() && r.isProxyWithFirewall() {
-		stateModel = r.configureFirewall(ctx, plan, stateModel, &resp.Diagnostics, &resp.State)
+		stateModel = r.configureFirewall(ctx, apiPlan, stateModel, &resp.Diagnostics, &resp.State)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -114,6 +119,51 @@ func (r *repositoryResource) Create(ctx context.Context, req resource.CreateRequ
 
 	// Save to state
 	resp.Diagnostics.Append(resp.State.Set(ctx, stateModel)...)
+}
+
+// suppressUnconfiguredConnectionFromConfig returns a copy of plan with
+// HttpClient.Connection zeroed out (nil) if the raw Config left http_client.connection
+// unset. This prevents outbound API requests from including a fully populated
+// connection object made up entirely of schema-computed defaults, which NXRM would
+// otherwise treat as explicitly-configured custom HTTP client settings.
+//
+// Proxy repository formats promote an HttpClient field (via embedding
+// RepositoryProxyModel); non-proxy formats don't have one, in which case plan is
+// returned unchanged. The original plan value is left untouched - callers should keep
+// using it for anything that feeds into Terraform state.
+func suppressUnconfiguredConnectionFromConfig(ctx context.Context, plan any, config tfsdk.Config) any {
+	planVal := reflect.ValueOf(plan)
+	if planVal.Kind() != reflect.Struct {
+		return plan
+	}
+
+	httpClientField := planVal.FieldByName("HttpClient")
+	if !httpClientField.IsValid() {
+		// Not a proxy repository format - nothing to do
+		return plan
+	}
+
+	// Decode raw Config into an instance of the same concrete type as plan
+	configPtr := reflect.New(planVal.Type())
+	diags := config.Get(ctx, configPtr.Interface())
+	if diags.HasError() {
+		return plan
+	}
+
+	configConnField := configPtr.Elem().FieldByName("HttpClient").FieldByName("Connection")
+	if !configConnField.IsValid() || !configConnField.IsNil() {
+		// Config explicitly set connection (or field doesn't exist) - leave plan untouched
+		return plan
+	}
+
+	// Config left `connection` unset: clone plan and nil its Connection so the
+	// outbound API request omits it, without touching the value used for state.
+	clonePtr := reflect.New(planVal.Type())
+	clonePtr.Elem().Set(planVal)
+	clonePtr.Elem().FieldByName("HttpClient").FieldByName("Connection").Set(
+		reflect.Zero(configConnField.Type()),
+	)
+	return clonePtr.Elem().Interface()
 }
 
 // validateAndParsePlan retrieves and validates the plan
@@ -353,18 +403,23 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 	// Setup context with auth
 	ctx = r.AuthContext(ctx)
 
+	// Build an API-safe copy of the plan that omits http_client.connection when the
+	// user's config left it unset, so we don't send computed defaults to NXRM as if
+	// they were explicitly configured. State is still populated from the original plan.
+	apiPlanModel := suppressUnconfiguredConnectionFromConfig(ctx, planModel, req.Config)
+
 	// Verify IQ connection if needed for firewall
-	if r.usesCapabilityBasedFirewall() && !r.verifyIQConnectionIfNeeded(ctx, planModel, &resp.Diagnostics) {
+	if r.usesCapabilityBasedFirewall() && !r.verifyIQConnectionIfNeeded(ctx, apiPlanModel, &resp.Diagnostics) {
 		return
 	}
 
 	// Update the repository
-	if !r.updateRepository(ctx, planModel, stateModel, &resp.Diagnostics) {
+	if !r.updateRepository(ctx, apiPlanModel, stateModel, &resp.Diagnostics) {
 		return
 	}
 
 	// Fetch complete data
-	apiResponse, ok := r.readCreatedRepository(ctx, planModel, &resp.Diagnostics, &resp.State)
+	apiResponse, ok := r.readCreatedRepository(ctx, apiPlanModel, &resp.Diagnostics, &resp.State)
 	if !ok {
 		return
 	}
@@ -378,7 +433,7 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	// Configure firewall if needed
 	if r.usesCapabilityBasedFirewall() && r.isProxyWithFirewall() {
-		stateModel = r.configureFirewall(ctx, planModel, stateModel, &resp.Diagnostics, &resp.State)
+		stateModel = r.configureFirewall(ctx, apiPlanModel, stateModel, &resp.Diagnostics, &resp.State)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/internal/provider/repository/repository_common.go
+++ b/internal/provider/repository/repository_common.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 
 	"terraform-provider-sonatyperepo/internal/provider/capability"
 	"terraform-provider-sonatyperepo/internal/provider/common"
@@ -81,7 +80,7 @@ func (r *repositoryResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Setup context with auth
-	ctx = r.setupAuthContext(ctx)
+	ctx = r.AuthContext(ctx)
 
 	// Verify IQ connection if needed for firewall
 	if r.NxrmVersion.SupportsCapabilities() && !r.verifyIQConnectionIfNeeded(ctx, plan, &resp.Diagnostics) {
@@ -137,18 +136,13 @@ func (r *repositoryResource) validateAndParsePlan(ctx context.Context, req resou
 	return plan, diags
 }
 
-// setupAuthContext adds authentication to the context
-func (r *repositoryResource) setupAuthContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, sonatyperepo.ContextBasicAuth, r.Auth)
-}
-
 // verifyIQConnectionIfNeeded checks IQ connection for proxy repositories with firewall enabled
 func (r *repositoryResource) verifyIQConnectionIfNeeded(ctx context.Context, plan any, respDiags *diag.Diagnostics) bool {
 	if r.RepositoryType != format.REPO_TYPE_PROXY || !r.RepositoryFormat.SupportsRepositoryFirewall() || !r.RepositoryFormat.GetRepositoryFirewallEnabled(plan) {
 		return true
 	}
 
-	iqCheckResponse, httpResponse, err := r.Client.ManageSonatypeRepositoryFirewallConfigurationAPI.VerifyIqConnection(ctx).Execute()
+	iqCheckResponse, httpResponse, err := r.Services.Configuration.VerifyIqConnection(ctx)
 	if err != nil || httpResponse.StatusCode != http.StatusOK || !*iqCheckResponse.Success {
 		respDiags.AddError("Sonatype IQ Connection not successful", "Unable to configure Repository Firewall as not connected to Sonatype IQ Server")
 		return false
@@ -158,7 +152,7 @@ func (r *repositoryResource) verifyIQConnectionIfNeeded(ctx context.Context, pla
 
 // createRepository creates the repository via API
 func (r *repositoryResource) createRepository(ctx context.Context, plan any, resp *resource.CreateResponse) bool {
-	httpResponse, err := r.RepositoryFormat.DoCreateRequest(plan, r.Client, ctx)
+	httpResponse, err := r.RepositoryFormat.DoCreateRequest(plan, r.Services.Repository, ctx)
 	if err != nil {
 		errors.HandleAPIError(
 			fmt.Sprintf("Error creating %s %s Repository", r.RepositoryFormat.Key(), r.RepositoryType.String()),
@@ -196,7 +190,7 @@ func (r *repositoryResource) readCreatedRepository(ctx context.Context, plan int
 	)
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		apiResponse, httpResponse, err = r.RepositoryFormat.DoReadRequest(plan, r.Client, ctx)
+		apiResponse, httpResponse, err = r.RepositoryFormat.DoReadRequest(plan, r.Services.Repository, ctx)
 		if err == nil && apiResponse != nil {
 			return apiResponse, true
 		}
@@ -304,14 +298,10 @@ func (r *repositoryResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Set API Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Make API Request
-	apiResponse, httpResponse, err := r.RepositoryFormat.DoReadRequest(stateModel, r.Client, ctx)
+	apiResponse, httpResponse, err := r.RepositoryFormat.DoReadRequest(stateModel, r.Services.Repository, ctx)
 
 	// Handle any errors
 	if err != nil {
@@ -352,7 +342,7 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 	resp.Diagnostics.Append(diags...)
 
 	// Setup context with auth
-	ctx = r.setupAuthContext(ctx)
+	ctx = r.AuthContext(ctx)
 
 	// Verify IQ connection if needed for firewall
 	if r.NxrmVersion.SupportsCapabilities() && !r.verifyIQConnectionIfNeeded(ctx, planModel, &resp.Diagnostics) {
@@ -391,7 +381,7 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 
 func (r *repositoryResource) updateRepository(ctx context.Context, planModel, stateModel any, respDiags *diag.Diagnostics) bool {
 	// Make API requet
-	httpResponse, err := r.RepositoryFormat.DoUpdateRequest(planModel, stateModel, r.Client, ctx)
+	httpResponse, err := r.RepositoryFormat.DoUpdateRequest(planModel, stateModel, r.Services.Repository, ctx)
 
 	// Handle any errors
 	if err != nil {
@@ -428,11 +418,7 @@ func (r *repositoryResource) Delete(ctx context.Context, req resource.DeleteRequ
 	}
 
 	// Request Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Make API request
 	repoNameStructField := reflect.Indirect(reflect.ValueOf(state)).FieldByName("Name").Interface()
@@ -463,7 +449,7 @@ func (r *repositoryResource) Delete(ctx context.Context, req resource.DeleteRequ
 func (r *repositoryResource) attemptDeleteWithRetries(ctx context.Context, repositoryName string, resp *resource.DeleteResponse) bool {
 	maxAttempts := 3
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		httpResponse, err := r.RepositoryFormat.DoDeleteRequest(repositoryName, r.Client, ctx)
+		httpResponse, err := r.RepositoryFormat.DoDeleteRequest(repositoryName, r.Services.Repository, ctx)
 
 		// Trap 500 Error as they occur when Repo is not in appropriate internal state
 		if httpResponse.StatusCode == http.StatusInternalServerError {
@@ -509,14 +495,10 @@ func (r *repositoryResource) ImportState(ctx context.Context, req resource.Impor
 	repositoryName := req.ID
 
 	// Set API Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Call format-specific import request to fetch repository data from API
-	apiResponse, httpResponse, err := r.RepositoryFormat.DoImportRequest(repositoryName, r.Client, ctx)
+	apiResponse, httpResponse, err := r.RepositoryFormat.DoImportRequest(repositoryName, r.Services.Repository, ctx)
 
 	// Handle errors
 	if err != nil {

--- a/internal/provider/repository/repository_common.go
+++ b/internal/provider/repository/repository_common.go
@@ -83,7 +83,7 @@ func (r *repositoryResource) Create(ctx context.Context, req resource.CreateRequ
 	ctx = r.AuthContext(ctx)
 
 	// Verify IQ connection if needed for firewall
-	if r.NxrmVersion.SupportsCapabilities() && !r.verifyIQConnectionIfNeeded(ctx, plan, &resp.Diagnostics) {
+	if r.usesCapabilityBasedFirewall() && !r.verifyIQConnectionIfNeeded(ctx, plan, &resp.Diagnostics) {
 		return
 	}
 
@@ -105,7 +105,7 @@ func (r *repositoryResource) Create(ctx context.Context, req resource.CreateRequ
 	stateModel = r.RepositoryFormat.UpdatePlanForState(stateModel)
 
 	// Configure firewall if needed
-	if r.NxrmVersion.SupportsCapabilities() && r.isProxyWithFirewall() {
+	if r.usesCapabilityBasedFirewall() && r.isProxyWithFirewall() {
 		stateModel = r.configureFirewall(ctx, plan, stateModel, &resp.Diagnostics, &resp.State)
 		if resp.Diagnostics.HasError() {
 			return
@@ -232,6 +232,15 @@ func (r *repositoryResource) isProxyWithFirewall() bool {
 	return r.RepositoryType == format.REPO_TYPE_PROXY && r.RepositoryFormat.SupportsRepositoryFirewall()
 }
 
+// usesCapabilityBasedFirewall reports whether firewall configuration for this
+// Nexus Repository Manager version must go through the Capability API. NXRM 3.94+
+// instead sets firewall mode inline on the repository payload itself (see
+// format.ComputeFirewallMode), so none of the Capability-based orchestration below
+// applies there.
+func (r *repositoryResource) usesCapabilityBasedFirewall() bool {
+	return r.NxrmVersion.SupportsCapabilities() && !r.NxrmVersion.SupportsInlineFirewall()
+}
+
 // configureFirewall handles firewall capability configuration for proxy repositories
 func (r *repositoryResource) configureFirewall(ctx context.Context, plan interface{}, stateModel interface{}, respDiags *diag.Diagnostics, respState *tfsdk.State) interface{} {
 	capabilityHelper := capability.NewCapabilityHelper(r.Client, common.CAPABILITY_TYPE_FIREWALL_AUDIT_QUARANTINE)
@@ -345,7 +354,7 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 	ctx = r.AuthContext(ctx)
 
 	// Verify IQ connection if needed for firewall
-	if r.NxrmVersion.SupportsCapabilities() && !r.verifyIQConnectionIfNeeded(ctx, planModel, &resp.Diagnostics) {
+	if r.usesCapabilityBasedFirewall() && !r.verifyIQConnectionIfNeeded(ctx, planModel, &resp.Diagnostics) {
 		return
 	}
 
@@ -368,7 +377,7 @@ func (r *repositoryResource) Update(ctx context.Context, req resource.UpdateRequ
 	stateModel = r.RepositoryFormat.UpdatePlanForState(stateModel)
 
 	// Configure firewall if needed
-	if r.NxrmVersion.SupportsCapabilities() && r.isProxyWithFirewall() {
+	if r.usesCapabilityBasedFirewall() && r.isProxyWithFirewall() {
 		stateModel = r.configureFirewall(ctx, planModel, stateModel, &resp.Diagnostics, &resp.State)
 		if resp.Diagnostics.HasError() {
 			return
@@ -537,7 +546,7 @@ func (r *repositoryResource) ImportState(ctx context.Context, req resource.Impor
 	stateModel = r.RepositoryFormat.UpdatePlanForState(stateModel)
 
 	// If PROXY that Supports Repository Firewall - check for any existing Capability
-	if r.NxrmVersion.SupportsCapabilities() && r.RepositoryType == format.REPO_TYPE_PROXY && r.RepositoryFormat.SupportsRepositoryFirewall() {
+	if r.usesCapabilityBasedFirewall() && r.RepositoryType == format.REPO_TYPE_PROXY && r.RepositoryFormat.SupportsRepositoryFirewall() {
 		// See if Capability alread exists
 		capabilityHelper := capability.NewCapabilityHelper(r.Client, common.CAPABILITY_TYPE_FIREWALL_AUDIT_QUARANTINE)
 		auditAndQuarantineCapability := capabilityHelper.FindCapabilityByRepositoryId(ctx, r.RepositoryFormat.GetRepositoryId(stateModel), &resp.Diagnostics)

--- a/internal/provider/repository/routing_rule.go
+++ b/internal/provider/repository/routing_rule.go
@@ -110,16 +110,12 @@ func (r *routingRuleResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	requestPayload := sonatyperepo.RoutingRuleXO{}
 	plan.MapToApi(&requestPayload)
 
-	apiResponse, err := r.Client.RoutingRulesAPI.CreateRoutingRule(ctx).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.RoutingRule.CreateRoutingRule(ctx, requestPayload)
 
 	// Handle Error
 	if err != nil {
@@ -166,7 +162,7 @@ func (r *routingRuleResource) Read(ctx context.Context, req resource.ReadRequest
 	ctx = r.AuthContext(ctx)
 
 	// Fetch routing rule from API
-	routingRule, httpResponse, err := r.Client.RoutingRulesAPI.GetRoutingRule(ctx, state.Name.ValueString()).Execute()
+	routingRule, httpResponse, err := r.Services.RoutingRule.GetRoutingRule(ctx, state.Name.ValueString())
 	if err != nil {
 		// Check if this is a 404 error
 		if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {
@@ -218,7 +214,7 @@ func (r *routingRuleResource) Update(ctx context.Context, req resource.UpdateReq
 	// Build request payload and make API call
 	requestPayload := sonatyperepo.RoutingRuleXO{}
 	plan.MapToApi(&requestPayload)
-	apiResponse, err := r.Client.RoutingRulesAPI.UpdateRoutingRule(ctx, state.Name.ValueString()).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.RoutingRule.UpdateRoutingRule(ctx, state.Name.ValueString(), requestPayload)
 
 	// Handle API response
 	if err != nil {
@@ -258,14 +254,10 @@ func (r *routingRuleResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Delete API Call
-	apiResponse, err := r.Client.RoutingRulesAPI.DeleteRoutingRule(ctx, state.Name.ValueString()).Execute()
+	apiResponse, err := r.Services.RoutingRule.DeleteRoutingRule(ctx, state.Name.ValueString())
 
 	// Handle Error(s)
 	if err != nil {

--- a/internal/provider/repository/routing_rule_data_source.go
+++ b/internal/provider/repository/routing_rule_data_source.go
@@ -29,8 +29,6 @@ import (
 
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -78,13 +76,9 @@ func (d *routingRuleDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	routingRuleResponse, httpResponse, err := d.Client.RoutingRulesAPI.GetRoutingRule(ctx, data.Name.ValueString()).Execute()
+	routingRuleResponse, httpResponse, err := d.Services.RoutingRule.GetRoutingRule(ctx, data.Name.ValueString())
 
 	state := model.RoutingRuleModelDS{}
 	if err != nil {

--- a/internal/provider/repository/routing_rules_data_source.go
+++ b/internal/provider/repository/routing_rules_data_source.go
@@ -28,8 +28,6 @@ import (
 
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -77,13 +75,9 @@ func (d *routingRulesDataSource) Schema(_ context.Context, req datasource.Schema
 func (d *routingRulesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state model.RoutingRulesModel
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	routingRulesResponse, httpResponse, err := d.Client.RoutingRulesAPI.GetRoutingRules(ctx).Execute()
+	routingRulesResponse, httpResponse, err := d.Services.RoutingRule.GetRoutingRules(ctx)
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable to list routing rules",

--- a/internal/provider/role/role_resource.go
+++ b/internal/provider/role/role_resource.go
@@ -95,14 +95,10 @@ func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 	apiBody := sonatyperepo.NewRoleXORequest()
 	plan.MapToApi(apiBody)
-	_, httpResponse, err := r.Client.SecurityManagementRolesAPI.Create(ctx).Body(*apiBody).Execute()
+	_, httpResponse, err := r.Services.Role.CreateRole(ctx, *apiBody)
 
 	if err != nil {
 		errors.HandleAPIError(
@@ -141,14 +137,10 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.SecurityManagementRolesAPI.GetRole(ctx, state.Id.ValueString()).Execute()
+	apiResponse, httpResponse, err := r.Services.Role.GetRole(ctx, state.Id.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == 404 {
@@ -196,14 +188,10 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Call API to Update
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 	apiBody := sonatyperepo.NewRoleXORequest()
 	plan.MapToApi(apiBody)
-	httpResponse, err := r.Client.SecurityManagementRolesAPI.Update(ctx, state.Id.ValueString()).Body(*apiBody).Execute()
+	httpResponse, err := r.Services.Role.UpdateRole(ctx, state.Id.ValueString(), *apiBody)
 
 	if err != nil {
 		errors.HandleAPIError(
@@ -241,13 +229,9 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	httpResponse, err := r.Client.SecurityManagementRolesAPI.Delete(ctx, state.Id.ValueString()).Execute()
+	httpResponse, err := r.Services.Role.DeleteRole(ctx, state.Id.ValueString())
 
 	// Handle Error
 	if err != nil {

--- a/internal/provider/role/roles_data_source.go
+++ b/internal/provider/role/roles_data_source.go
@@ -28,8 +28,6 @@ import (
 
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -80,13 +78,9 @@ func (d *rolesDataSource) Schema(_ context.Context, req datasource.SchemaRequest
 func (d *rolesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state model.RolesModel
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	rolesResponse, httpResponse, err := d.Client.SecurityManagementRolesAPI.GetRoles(ctx).Execute()
+	rolesResponse, httpResponse, err := d.Services.Role.GetRoles(ctx)
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable to list roles",

--- a/internal/provider/system/anonymous_access_resource.go
+++ b/internal/provider/system/anonymous_access_resource.go
@@ -69,14 +69,10 @@ func (r *anonymousAccessSystemResource) ImportState(ctx context.Context, req res
 	// we don't need to parse the import ID. We just read the current configuration.
 
 	// Set up authentication context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read current anonymous access settings from the API
-	apiResponse, httpResponse, err := r.Client.SecurityManagementAnonymousAccessAPI.Read1(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.AnonymousAccess.GetAnonymousAccessSettings(ctx)
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusForbidden {
@@ -124,11 +120,7 @@ func (r *anonymousAccessSystemResource) Create(ctx context.Context, req resource
 	}
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	payload := sonatyperepo.AnonymousAccessSettingsXO{
 		Enabled:   plan.Enabled.ValueBoolPointer(),
@@ -136,7 +128,7 @@ func (r *anonymousAccessSystemResource) Create(ctx context.Context, req resource
 		UserId:    plan.UserId.ValueStringPointer(),
 	}
 
-	_, httpResponse, err := r.Client.SecurityManagementAnonymousAccessAPI.Update1(ctx).Body(payload).Execute()
+	_, httpResponse, err := r.Services.AnonymousAccess.UpdateAnonymousAccessSettings(ctx, payload)
 
 	// Handle Error
 	if err != nil {
@@ -185,14 +177,10 @@ func (r *anonymousAccessSystemResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.SecurityManagementAnonymousAccessAPI.Read1(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.AnonymousAccess.GetAnonymousAccessSettings(ctx)
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusForbidden {
@@ -232,11 +220,7 @@ func (r *anonymousAccessSystemResource) Update(ctx context.Context, req resource
 		tflog.Error(ctx, fmt.Sprintf("Getting plan data has errors: %v", resp.Diagnostics.Errors()))
 		return
 	}
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Update API Call
 	payload := sonatyperepo.AnonymousAccessSettingsXO{
@@ -245,7 +229,7 @@ func (r *anonymousAccessSystemResource) Update(ctx context.Context, req resource
 		UserId:    plan.UserId.ValueStringPointer(),
 	}
 
-	apiResponse, httpResponse, err := r.Client.SecurityManagementAnonymousAccessAPI.Update1(ctx).Body(payload).Execute()
+	apiResponse, httpResponse, err := r.Services.AnonymousAccess.UpdateAnonymousAccessSettings(ctx, payload)
 
 	// Handle Error
 	if err != nil {
@@ -297,11 +281,7 @@ func (r *anonymousAccessSystemResource) Delete(ctx context.Context, req resource
 	}
 
 	//
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Update API Call
 	payload := sonatyperepo.AnonymousAccessSettingsXO{
@@ -310,7 +290,7 @@ func (r *anonymousAccessSystemResource) Delete(ctx context.Context, req resource
 		UserId:    common.StringPointer(common.DEFAULT_ANONYMOUS_USERNAME),
 	}
 
-	_, httpResponse, err := r.Client.SecurityManagementAnonymousAccessAPI.Update1(ctx).Body(payload).Execute()
+	_, httpResponse, err := r.Services.AnonymousAccess.UpdateAnonymousAccessSettings(ctx, payload)
 
 	// Handle Error
 	if err != nil {

--- a/internal/provider/system/config_http_resource.go
+++ b/internal/provider/system/config_http_resource.go
@@ -154,7 +154,7 @@ func (r *systemConfigHttpResource) Read(ctx context.Context, req resource.ReadRe
 
 	// Call API to Create
 	ctx = r.AuthContext(ctx)
-	apiResponse, httpResponse, err := r.Client.ManageSonatypeHTTPSystemSettingsAPI.GetHttpSettings(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.HttpSettings.GetHttpSettings(ctx)
 
 	// Handle any errors
 	if err != nil {
@@ -201,7 +201,7 @@ func (r *systemConfigHttpResource) Update(ctx context.Context, req resource.Upda
 func (r *systemConfigHttpResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	// Call API to Create
 	ctx = r.AuthContext(ctx)
-	httpResponse, err := r.Client.ManageSonatypeHTTPSystemSettingsAPI.ResetHttpSettings(ctx).Execute()
+	httpResponse, err := r.Services.HttpSettings.ResetHttpSettings(ctx)
 
 	// Handle Error
 	if err != nil {
@@ -248,7 +248,7 @@ func (r *systemConfigHttpResource) updateHttpSettings(ctx context.Context, plan 
 	ctx = r.AuthContext(ctx)
 	httpSettings := v3.NewHttpSettingsXoWithDefaults()
 	plan.MapToApi(httpSettings)
-	httpResponse, err := r.Client.ManageSonatypeHTTPSystemSettingsAPI.UpdateHttpSettings(ctx).Body(*httpSettings).Execute()
+	httpResponse, err := r.Services.HttpSettings.UpdateHttpSettings(ctx, *httpSettings)
 
 	// Handle Errors
 	if err != nil {
@@ -271,7 +271,7 @@ func (r *systemConfigHttpResource) updateHttpSettings(ctx context.Context, plan 
 	}
 
 	// Read Data back from API
-	apiResponse, httpResponse, err := r.Client.ManageSonatypeHTTPSystemSettingsAPI.GetHttpSettings(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.HttpSettings.GetHttpSettings(ctx)
 
 	// Handle any errors
 	if err != nil {

--- a/internal/provider/system/config_iq_connection_resource.go
+++ b/internal/provider/system/config_iq_connection_resource.go
@@ -113,14 +113,10 @@ func (r *systemConfigIqConnectionResource) Read(ctx context.Context, req resourc
 
 	priorTimeout := state.ConnectionTimeout // save before MapFromApi overwrites for NXRM 3.86/87
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.ManageSonatypeRepositoryFirewallConfigurationAPI.GetConfiguration1(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.Configuration.GetIqConnectionConfiguration(ctx)
 
 	if err != nil {
 		if httpResponse.StatusCode == 404 {
@@ -173,14 +169,10 @@ func (r *systemConfigIqConnectionResource) Update(ctx context.Context, req resou
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *systemConfigIqConnectionResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Disable API Call
-	httpResponse, err := r.Client.ManageSonatypeRepositoryFirewallConfigurationAPI.DisableIq(ctx).Execute()
+	httpResponse, err := r.Services.Configuration.DisableIq(ctx)
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusNotFound {
@@ -211,15 +203,11 @@ func (r *systemConfigIqConnectionResource) doUpdateRequest(ctx context.Context, 
 		return nil
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	apiModel := sonatyperepo.NewIqConnectionXoWithDefaults()
 	plan.MapToApi(apiModel)
-	_, httpResponse, err := r.Client.ManageSonatypeRepositoryFirewallConfigurationAPI.UpdateConfiguration1(ctx).Body(*apiModel).Execute()
+	_, httpResponse, err := r.Services.Configuration.UpdateIqConnectionConfiguration(ctx, *apiModel)
 
 	// Handle Error
 	if err != nil {

--- a/internal/provider/system/config_ldap_resource.go
+++ b/internal/provider/system/config_ldap_resource.go
@@ -33,8 +33,6 @@ import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
 
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
-
 	"github.com/sonatype-nexus-community/terraform-provider-shared/errors"
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 )
@@ -152,12 +150,8 @@ func (r *systemConfigLdapResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
-	apiResponse, err := r.Client.SecurityManagementLDAPAPI.CreateLdapServer(ctx).Body(*plan.ToApiCreateModel()).Execute()
+	ctx = r.AuthContext(ctx)
+	apiResponse, err := r.Services.Configuration.CreateLdapServer(ctx, *plan.ToApiCreateModel())
 
 	// Handle Error
 	if err != nil || apiResponse.StatusCode != http.StatusCreated {
@@ -171,7 +165,7 @@ func (r *systemConfigLdapResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// Id & Order are not known until Create Request - we need to call GET now to obtain that
-	ldapResonse, httpResponse, err := r.Client.SecurityManagementLDAPAPI.GetLdapServer(ctx, plan.Name.ValueString()).Execute()
+	ldapResonse, httpResponse, err := r.Services.Configuration.GetLdapServer(ctx, plan.Name.ValueString())
 	if err != nil || httpResponse.StatusCode != http.StatusOK {
 		errors.HandleAPIError(
 			"Error creating LDAP Connection - connection may be partially created",
@@ -203,14 +197,10 @@ func (r *systemConfigLdapResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.SecurityManagementLDAPAPI.GetLdapServer(ctx, state.Name.ValueString()).Execute()
+	apiResponse, httpResponse, err := r.Services.Configuration.GetLdapServer(ctx, state.Name.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == 404 {
@@ -259,16 +249,12 @@ func (r *systemConfigLdapResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Call API to Update
 	plan.Id = state.Id
 	body := plan.ToApiUpdateModel()
-	httpResponse, err := r.Client.SecurityManagementLDAPAPI.UpdateLdapServer(ctx, state.Name.ValueString()).Body(*body).Execute()
+	httpResponse, err := r.Services.Configuration.UpdateLdapServer(ctx, state.Name.ValueString(), *body)
 
 	// Handle Error
 	if err != nil || httpResponse.StatusCode != http.StatusNoContent {
@@ -300,13 +286,9 @@ func (r *systemConfigLdapResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	httpResponse, err := r.Client.SecurityManagementLDAPAPI.DeleteLdapServer(ctx, state.Name.ValueString()).Execute()
+	httpResponse, err := r.Services.Configuration.DeleteLdapServer(ctx, state.Name.ValueString())
 
 	// Handle Error
 	if err != nil || httpResponse.StatusCode != http.StatusNoContent {

--- a/internal/provider/system/config_license_resource.go
+++ b/internal/provider/system/config_license_resource.go
@@ -35,8 +35,6 @@ import (
 
 	b64 "encoding/base64"
 
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
-
 	"github.com/sonatype-nexus-community/terraform-provider-shared/errors"
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 )
@@ -112,14 +110,10 @@ func (r *systemConfigProductLicenseResource) Read(ctx context.Context, req resou
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.ProductLicensingAPI.GetLicenseStatus(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.License.GetLicenseStatus(ctx)
 
 	if err != nil {
 		errors.HandleAPIError(
@@ -170,12 +164,8 @@ func (r *systemConfigProductLicenseResource) Update(ctx context.Context, req res
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *systemConfigProductLicenseResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
-	httpResponse, err := r.Client.ProductLicensingAPI.RemoveLicense(ctx).Execute()
+	ctx = r.AuthContext(ctx)
+	httpResponse, err := r.Services.License.RemoveLicense(ctx)
 
 	// Handle Error
 	if err != nil || httpResponse.StatusCode != http.StatusNoContent {
@@ -220,13 +210,9 @@ func (r *systemConfigProductLicenseResource) updateProductLicense(ctx context.Co
 	defer func() { _ = os.Remove(productLicenseFileName) }()
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	apiResponse, httpReponse, err := r.Client.ProductLicensingAPI.SetLicense(ctx).Body(productLicenseFile).Execute()
+	apiResponse, httpReponse, err := r.Services.License.SetLicense(ctx, productLicenseFile)
 
 	// Handle Error
 	if err != nil || httpReponse.StatusCode != http.StatusOK {

--- a/internal/provider/system/config_mail_resource.go
+++ b/internal/provider/system/config_mail_resource.go
@@ -109,11 +109,7 @@ func (r *systemConfigMailResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	requestPayload := sonatyperepo.ApiEmailConfiguration{
 		Enabled:                       plan.Enabled.ValueBoolPointer(),
@@ -129,7 +125,7 @@ func (r *systemConfigMailResource) Create(ctx context.Context, req resource.Crea
 		SslServerIdentityCheckEnabled: plan.SSLServerIdentityCheckEnabled.ValueBoolPointer(),
 		NexusTrustStoreEnabled:        plan.NexusTrustStoreEnabled.ValueBoolPointer(),
 	}
-	apiResponse, err := r.Client.EmailAPI.SetEmailConfiguration(ctx).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.Configuration.SetEmailConfiguration(ctx, requestPayload)
 
 	// Handle Error
 	if err != nil {
@@ -165,14 +161,10 @@ func (r *systemConfigMailResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.EmailAPI.GetEmailConfiguration(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.Configuration.GetEmailConfiguration(ctx)
 
 	if err != nil {
 		if httpResponse.StatusCode == 404 {
@@ -216,11 +208,7 @@ func (r *systemConfigMailResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Call API to Update
 	requestPayload := sonatyperepo.ApiEmailConfiguration{
@@ -237,7 +225,7 @@ func (r *systemConfigMailResource) Update(ctx context.Context, req resource.Upda
 		SslServerIdentityCheckEnabled: plan.SSLServerIdentityCheckEnabled.ValueBoolPointer(),
 		NexusTrustStoreEnabled:        plan.NexusTrustStoreEnabled.ValueBoolPointer(),
 	}
-	apiResponse, err := r.Client.EmailAPI.SetEmailConfiguration(ctx).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.Configuration.SetEmailConfiguration(ctx, requestPayload)
 
 	// Handle Error
 	if err != nil {
@@ -273,13 +261,9 @@ func (r *systemConfigMailResource) Delete(ctx context.Context, req resource.Dele
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	apiResponse, err := r.Client.EmailAPI.DeleteEmailConfiguration(ctx).Execute()
+	apiResponse, err := r.Services.Configuration.DeleteEmailConfiguration(ctx)
 
 	// Handle Error
 	if err != nil {

--- a/internal/provider/system/config_mail_resource_test.go
+++ b/internal/provider/system/config_mail_resource_test.go
@@ -40,9 +40,9 @@ func TestAccSystemConfigMailResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Verify
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "enabled", "false"),
-					resource.TestCheckResourceAttr(resourceNameConfigMail, "host", fmt.Sprintf("something.tld.%s", randomString)),
+					resource.TestCheckResourceAttr(resourceNameConfigMail, "host", "example.com"),
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "port", "587"),
-					resource.TestCheckResourceAttr(resourceNameConfigMail, "username", "someone"),
+					resource.TestCheckResourceAttr(resourceNameConfigMail, "username", fmt.Sprintf("someone-%s", randomString)),
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "password", "sensitive-value"),
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "from_address", "no-where@somewhere.tld"),
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "start_tls_enabled", "false"),
@@ -123,9 +123,9 @@ func TestAccSystemConfigMailResourceUpdateAfterImport(t *testing.T) {
 				Config: getSytemConfigMailResourceConfigUpdated(updatedRandomString),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "enabled", "true"),
-					resource.TestCheckResourceAttr(resourceNameConfigMail, "host", fmt.Sprintf("updated.tld.%s", updatedRandomString)),
+					resource.TestCheckResourceAttr(resourceNameConfigMail, "host", "example.org"),
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "port", "465"),
-					resource.TestCheckResourceAttr(resourceNameConfigMail, "username", "updated-user"),
+					resource.TestCheckResourceAttr(resourceNameConfigMail, "username", fmt.Sprintf("updated-user-%s", updatedRandomString)),
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "from_address", "updated@somewhere.tld"),
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "start_tls_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceNameConfigMail, "ssl_on_connect_enabled", "true"),
@@ -140,9 +140,9 @@ func getSytemConfigMailResourceConfig(randomString string) string {
 	return fmt.Sprintf(utils_test.ProviderConfig+`
 resource "%s" "email" {
 	enabled = false
-	host = "something.tld.%s"
+	host = "example.com"
 	port = 587
-	username = "someone"
+	username = "someone-%s"
 	password = "sensitive-value"
 	from_address = "no-where@somewhere.tld"
 	start_tls_enabled = false
@@ -159,9 +159,9 @@ func getSytemConfigMailResourceConfigUpdated(randomString string) string {
 	return fmt.Sprintf(utils_test.ProviderConfig+`
 resource "%s" "email" {
 	enabled = true
-	host = "updated.tld.%s"
+	host = "example.org"
 	port = 465
-	username = "updated-user"
+	username = "updated-user-%s"
 	password = "updated-sensitive-value"
 	from_address = "updated@somewhere.tld"
 	start_tls_enabled = true

--- a/internal/provider/system/security_realms.go
+++ b/internal/provider/system/security_realms.go
@@ -34,8 +34,6 @@ import (
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
 
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
-
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 )
 
@@ -96,7 +94,7 @@ func (r *securityRealmsResource) ImportState(ctx context.Context, req resource.I
 	ctx = r.AuthContext(ctx)
 
 	// Read current configuration from the API
-	apiResponse, httpResponse, err := r.Client.SecurityManagementRealmsAPI.GetActiveRealms(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.Realms.GetActiveRealms(ctx)
 	if err != nil {
 		if httpResponse != nil && httpResponse.StatusCode == 404 {
 			resp.Diagnostics.AddError(
@@ -161,11 +159,7 @@ func (r *securityRealmsResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Set up authentication context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Convert list to appropriate format
 	activeRealms, err := r.convertActiveRealms(plan.Active)
@@ -180,7 +174,7 @@ func (r *securityRealmsResource) Create(ctx context.Context, req resource.Create
 	tflog.Debug(ctx, fmt.Sprintf("Creating security realms configuration with realms: %v", activeRealms))
 
 	// Call API to Create
-	apiResponse, err := r.Client.SecurityManagementRealmsAPI.SetActiveRealms(ctx).Body(activeRealms).Execute()
+	apiResponse, err := r.Services.Realms.SetActiveRealms(ctx, activeRealms)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			errorSettingSecurityRealms,
@@ -219,7 +213,7 @@ func (r *securityRealmsResource) Read(ctx context.Context, req resource.ReadRequ
 	ctx = r.AuthContext(ctx)
 
 	// Read API Call - GetActiveRealms returns []string directly
-	apiResponse, httpResponse, err := r.Client.SecurityManagementRealmsAPI.GetActiveRealms(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.Realms.GetActiveRealms(ctx)
 	if err != nil {
 		r.handleReadError(ctx, resp, httpResponse, err)
 		return
@@ -255,11 +249,7 @@ func (r *securityRealmsResource) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Convert list to appropriate format
 	activeRealms, err := r.convertActiveRealms(plan.Active)
@@ -274,7 +264,7 @@ func (r *securityRealmsResource) Update(ctx context.Context, req resource.Update
 	tflog.Debug(ctx, fmt.Sprintf("Updating security realms configuration with realms: %v", activeRealms))
 
 	// Call API to Update
-	apiResponse, err := r.Client.SecurityManagementRealmsAPI.SetActiveRealms(ctx).Body(activeRealms).Execute()
+	apiResponse, err := r.Services.Realms.SetActiveRealms(ctx, activeRealms)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			errorSettingSecurityRealms,
@@ -315,11 +305,7 @@ func (r *securityRealmsResource) Delete(ctx context.Context, req resource.Delete
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Reset to default security realms - Nexus requires at least one realm
 	defaultRealms := []string{"NexusAuthenticatingRealm"}
@@ -327,7 +313,7 @@ func (r *securityRealmsResource) Delete(ctx context.Context, req resource.Delete
 	tflog.Debug(ctx, fmt.Sprintf("Resetting security realms to default configuration: %v", defaultRealms))
 
 	// Call API to reset to defaults
-	apiResponse, err := r.Client.SecurityManagementRealmsAPI.SetActiveRealms(ctx).Body(defaultRealms).Execute()
+	apiResponse, err := r.Services.Realms.SetActiveRealms(ctx, defaultRealms)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			errorSettingSecurityRealms,

--- a/internal/provider/system/security_saml.go
+++ b/internal/provider/system/security_saml.go
@@ -18,7 +18,6 @@ package system
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -103,14 +102,10 @@ func (r *securitySamlResource) ImportState(ctx context.Context, req resource.Imp
 	})
 
 	// Set up authentication context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Get the current SAML configuration from the API
-	httpResponse, err := r.Client.SecurityManagementSAMLAPI.GetSamlConfiguration(ctx).Execute()
+	samlConfig, httpResponse, err := r.Services.Saml.GetSamlConfiguration(ctx)
 	if err != nil {
 		if httpResponse != nil && httpResponse.StatusCode == 404 {
 			resp.Diagnostics.AddError(
@@ -126,18 +121,8 @@ func (r *securitySamlResource) ImportState(ctx context.Context, req resource.Imp
 		return
 	}
 
-	// Parse the response body to get the SamlConfigurationXO
-	var samlConfig sonatyperepo.SamlConfigurationXO
-	if err := json.NewDecoder(httpResponse.Body).Decode(&samlConfig); err != nil {
-		resp.Diagnostics.AddError(
-			"Error parsing SAML Configuration response",
-			fmt.Sprintf("Unable to parse SAML Configuration response: %s", err),
-		)
-		return
-	}
-
 	var state model.SecuritySamlModel
-	state.MapFromApi(&samlConfig)
+	state.MapFromApi(samlConfig)
 
 	// Set the populated state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -159,11 +144,7 @@ func (r *securitySamlResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	// Set up authentication context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	requestPayload := sonatyperepo.SamlConfigurationXO{
 		IdpMetadata:                plan.IdpMetadata.ValueString(),
@@ -179,7 +160,7 @@ func (r *securitySamlResource) Create(ctx context.Context, req resource.CreateRe
 
 	tflog.Debug(ctx, fmt.Sprintf("Creating security saml configuration with : %v", requestPayload))
 
-	apiResponse, err := r.Client.SecurityManagementSAMLAPI.PutSamlConfiguration(ctx).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.Saml.PutSamlConfiguration(ctx, requestPayload)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Security SAML configuration",
@@ -212,13 +193,9 @@ func (r *securitySamlResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	httpResponse, err := r.Client.SecurityManagementSAMLAPI.GetSamlConfiguration(ctx).Execute()
+	samlConfig, httpResponse, err := r.Services.Saml.GetSamlConfiguration(ctx)
 	if err != nil {
 		if httpResponse != nil && httpResponse.StatusCode == 404 {
 			resp.State.RemoveResource(ctx)
@@ -239,18 +216,8 @@ func (r *securitySamlResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	// Parse the response body to get the SamlConfigurationXO
-	var samlConfig sonatyperepo.SamlConfigurationXO
-	if err := json.NewDecoder(httpResponse.Body).Decode(&samlConfig); err != nil {
-		resp.Diagnostics.AddError(
-			"Error parsing SAML Configuration response",
-			fmt.Sprintf("Unable to parse SAML Configuration response: %s", err),
-		)
-		return
-	}
-
 	// Update state with values from API using MapFromApi
-	state.MapFromApi(&samlConfig)
+	state.MapFromApi(samlConfig)
 
 	tflog.Debug(ctx, "Successfully read security SAML configuration from API")
 
@@ -277,11 +244,7 @@ func (r *securitySamlResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	requestPayload := sonatyperepo.SamlConfigurationXO{
 		IdpMetadata:                plan.IdpMetadata.ValueString(),
@@ -298,7 +261,7 @@ func (r *securitySamlResource) Update(ctx context.Context, req resource.UpdateRe
 	tflog.Debug(ctx, fmt.Sprintf("Updating security SAML configuration with : %v", requestPayload))
 
 	// Call API to Update
-	apiResponse, err := r.Client.SecurityManagementSAMLAPI.PutSamlConfiguration(ctx).Body(requestPayload).Execute()
+	apiResponse, err := r.Services.Saml.PutSamlConfiguration(ctx, requestPayload)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating Security SAML configuration",
@@ -331,13 +294,9 @@ func (r *securitySamlResource) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	apiResponse, err := r.Client.SecurityManagementSAMLAPI.DeleteSamlConfiguration(ctx).Execute()
+	apiResponse, err := r.Services.Saml.DeleteSamlConfiguration(ctx)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting Security SAML configuration",

--- a/internal/provider/system/security_ssl_truststore_resource.go
+++ b/internal/provider/system/security_ssl_truststore_resource.go
@@ -34,7 +34,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 
 	"github.com/sonatype-nexus-community/terraform-provider-shared/errors"
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
@@ -111,7 +110,7 @@ func (r *securitySslTruststoreResource) Create(ctx context.Context, req resource
 	pemValue = strings.TrimRight(pemValue, "\n") + "\n"
 	plan.Pem = types.StringValue(pemValue)
 
-	apiResponse, httpResponse, err := r.Client.SecurityCertificatesAPI.AddCertificate(r.AuthContext(ctx)).Body(pemValue).Execute()
+	apiResponse, httpResponse, err := r.Services.Certificates.AddCertificate(r.AuthContext(ctx), pemValue)
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusForbidden {
@@ -149,13 +148,9 @@ func (r *securitySslTruststoreResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	apiResponse, httpResponse, err := r.Client.SecurityCertificatesAPI.GetTrustStoreCertificates(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.Certificates.GetTrustStoreCertificates(ctx)
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusForbidden {
@@ -234,13 +229,9 @@ func (r *securitySslTruststoreResource) Delete(ctx context.Context, req resource
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	httpResponse, err := r.Client.SecurityCertificatesAPI.RemoveCertificate(ctx, state.Id.ValueString()).Execute()
+	httpResponse, err := r.Services.Certificates.RemoveCertificate(ctx, state.Id.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusNotFound {

--- a/internal/provider/system/security_ssrf_protection_resource.go
+++ b/internal/provider/system/security_ssrf_protection_resource.go
@@ -18,9 +18,7 @@ package system
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -77,22 +75,7 @@ func (r *securitySsrfProtectionResource) Schema(_ context.Context, _ resource.Sc
 
 // fetchSsrfConfig reads the current SSRF Protection configuration from the API.
 func (r *securitySsrfProtectionResource) fetchSsrfConfig(ctx context.Context) (*sonatyperepo.SsrfProtectionConfigurationXO, *http.Response, error) {
-	httpResponse, err := r.Client.SecurityManagementSSRFProtectionAPI.GetConfiguration(ctx).Execute()
-	if err != nil {
-		return nil, httpResponse, err
-	}
-
-	body, err := io.ReadAll(httpResponse.Body)
-	if err != nil {
-		return nil, httpResponse, fmt.Errorf("could not read response body: %w", err)
-	}
-
-	var cfg sonatyperepo.SsrfProtectionConfigurationXO
-	if err := json.Unmarshal(body, &cfg); err != nil {
-		return nil, httpResponse, fmt.Errorf("could not parse response: %w", err)
-	}
-
-	return &cfg, httpResponse, nil
+	return r.Services.SsrfProtection.GetSsrfProtectionConfiguration(ctx)
 }
 
 // ImportState imports the resource into Terraform state.
@@ -146,7 +129,7 @@ func (r *securitySsrfProtectionResource) Create(ctx context.Context, req resourc
 	payload := sonatyperepo.SsrfProtectionConfigurationXO{}
 	plan.MapToApi(&payload)
 
-	httpResponse, err := r.Client.SecurityManagementSSRFProtectionAPI.UpdateConfiguration(ctx).Body(payload).Execute()
+	httpResponse, err := r.Services.SsrfProtection.UpdateSsrfProtectionConfiguration(ctx, payload)
 
 	if err != nil {
 		if httpResponse != nil && httpResponse.StatusCode == http.StatusForbidden {
@@ -234,7 +217,7 @@ func (r *securitySsrfProtectionResource) Update(ctx context.Context, req resourc
 	payload := sonatyperepo.SsrfProtectionConfigurationXO{}
 	plan.MapToApi(&payload)
 
-	httpResponse, err := r.Client.SecurityManagementSSRFProtectionAPI.UpdateConfiguration(ctx).Body(payload).Execute()
+	httpResponse, err := r.Services.SsrfProtection.UpdateSsrfProtectionConfiguration(ctx, payload)
 
 	if err != nil {
 		if httpResponse != nil && httpResponse.StatusCode == http.StatusForbidden {
@@ -289,7 +272,7 @@ func (r *securitySsrfProtectionResource) Delete(ctx context.Context, req resourc
 		AllowedIPs:     []string{},
 	}
 
-	httpResponse, err := r.Client.SecurityManagementSSRFProtectionAPI.UpdateConfiguration(ctx).Body(payload).Execute()
+	httpResponse, err := r.Services.SsrfProtection.UpdateSsrfProtectionConfiguration(ctx, payload)
 
 	if err != nil {
 		if httpResponse != nil && httpResponse.StatusCode == http.StatusForbidden {

--- a/internal/provider/system/security_user_tokens_data_source.go
+++ b/internal/provider/system/security_user_tokens_data_source.go
@@ -28,8 +28,6 @@ import (
 
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -68,14 +66,10 @@ func (d *securityUserTokenDataSource) Schema(_ context.Context, req datasource.S
 
 // Read refreshes the Terraform state with the latest data.
 func (d *securityUserTokenDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := d.Client.SecurityManagementUserTokensAPI.ServiceStatus(ctx).Execute()
+	apiResponse, httpResponse, err := d.Services.UserTokens.ServiceStatus(ctx)
 
 	if err != nil {
 		errors.HandleAPIError(

--- a/internal/provider/system/security_user_tokens_resource.go
+++ b/internal/provider/system/security_user_tokens_resource.go
@@ -89,14 +89,10 @@ func (r *securityUserTokenResource) ImportState(ctx context.Context, req resourc
 	// we don't need to parse the import ID. We just read the current configuration.
 
 	// Set up authentication context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read current user token settings from the API
-	apiResponse, httpResponse, err := r.Client.SecurityManagementUserTokensAPI.ServiceStatus(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.UserTokens.ServiceStatus(ctx)
 
 	if err != nil || httpResponse.StatusCode != http.StatusOK {
 		errors.HandleAPIError(
@@ -135,11 +131,7 @@ func (r *securityUserTokenResource) Create(ctx context.Context, req resource.Cre
 	}
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	payload := sonatyperepo.UserTokensApiModel{}
 	plan.MapToApi(&payload)
@@ -178,14 +170,10 @@ func (r *securityUserTokenResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.SecurityManagementUserTokensAPI.ServiceStatus(ctx).Execute()
+	apiResponse, httpResponse, err := r.Services.UserTokens.ServiceStatus(ctx)
 
 	if err != nil || httpResponse.StatusCode != http.StatusOK {
 		errors.HandleAPIError(
@@ -216,17 +204,13 @@ func (r *securityUserTokenResource) Update(ctx context.Context, req resource.Upd
 		tflog.Error(ctx, fmt.Sprintf("Getting plan data has errors: %v", resp.Diagnostics.Errors()))
 		return
 	}
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Update API Call
 	payload := sonatyperepo.UserTokensApiModel{}
 	plan.MapToApi(&payload)
 
-	apiResponse, httpResponse, err := r.Client.SecurityManagementUserTokensAPI.SetServiceStatus(ctx).Body(payload).Execute()
+	apiResponse, httpResponse, err := r.Services.UserTokens.SetServiceStatus(ctx, payload)
 
 	// Handle Error
 	if err != nil || httpResponse.StatusCode != http.StatusOK {
@@ -260,11 +244,7 @@ func (r *securityUserTokenResource) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Instead of deleting, we disable the user token feature
 	defaultExpirationDays := common.SECURITY_USER_TOKEN_DEFAULT_EXPIRATION_DAYS
@@ -273,7 +253,7 @@ func (r *securityUserTokenResource) Delete(ctx context.Context, req resource.Del
 		ExpirationDays: &defaultExpirationDays,
 	}
 
-	_, httpResponse, err := r.Client.SecurityManagementUserTokensAPI.SetServiceStatus(ctx).Body(payload).Execute()
+	_, httpResponse, err := r.Services.UserTokens.SetServiceStatus(ctx, payload)
 
 	// Handle Error
 	if err != nil || httpResponse.StatusCode != http.StatusOK {

--- a/internal/provider/task/task_common.go
+++ b/internal/provider/task/task_common.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 
 	"github.com/sonatype-nexus-community/terraform-provider-shared/errors"
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
@@ -79,14 +78,10 @@ func (t *taskResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Request Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		t.Auth,
-	)
+	ctx = t.AuthContext(ctx)
 
 	// Make API requet
-	taskCreateResponse, httpResponse, err := t.TaskType.DoCreateRequest(plan, t.Client, ctx, t.NxrmVersion)
+	taskCreateResponse, httpResponse, err := t.TaskType.DoCreateRequest(plan, t.Services.Task, ctx, t.NxrmVersion)
 
 	// Handle Errors
 	if err != nil {
@@ -137,14 +132,10 @@ func (t *taskResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	// Request Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		t.Auth,
-	)
+	ctx = t.AuthContext(ctx)
 
 	// Make API request
-	apiResponse, httpResponse, err := t.Client.TasksAPI.GetTaskById(ctx, taskId.ValueString()).Execute()
+	apiResponse, httpResponse, err := t.Services.Task.GetTaskById(ctx, taskId.ValueString())
 
 	if err != nil {
 		if httpResponse != nil && httpResponse.StatusCode == http.StatusNotFound {
@@ -189,14 +180,10 @@ func (t *taskResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Request Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		t.Auth,
-	)
+	ctx = t.AuthContext(ctx)
 
 	// Make API requet
-	httpResponse, err := t.TaskType.DoUpdateRequest(planModel, stateModel, t.Client, ctx, t.NxrmVersion)
+	httpResponse, err := t.TaskType.DoUpdateRequest(planModel, stateModel, t.Services.Task, ctx, t.NxrmVersion)
 
 	// Handle any errors
 	if err != nil {
@@ -238,11 +225,7 @@ func (t *taskResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	}
 
 	// Request Context
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		t.Auth,
-	)
+	ctx = t.AuthContext(ctx)
 
 	// Make API request
 	taskIdStructField := reflect.Indirect(reflect.ValueOf(state)).FieldByName("Id").Interface()
@@ -260,7 +243,7 @@ func (t *taskResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	success := false
 
 	for !success && attempts < maxAttempts {
-		httpResponse, err := t.Client.TasksAPI.DeleteTaskById(ctx, taskId.ValueString()).Execute()
+		httpResponse, err := t.Services.Task.DeleteTaskById(ctx, taskId.ValueString())
 
 		// Trap 500 Error as they occur when Repo is not in appropriate internal state
 		if httpResponse.StatusCode == http.StatusInternalServerError {

--- a/internal/provider/task/task_data_source.go
+++ b/internal/provider/task/task_data_source.go
@@ -29,8 +29,6 @@ import (
 
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -82,13 +80,9 @@ func (d *taskDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	taskResponse, httpResponse, err := d.Client.TasksAPI.GetTaskById(ctx, data.Id.ValueString()).Execute()
+	taskResponse, httpResponse, err := d.Services.Task.GetTaskById(ctx, data.Id.ValueString())
 
 	state := model.TaskModelSimple{}
 	if err != nil {

--- a/internal/provider/task/task_type/blobstore.go
+++ b/internal/provider/task/task_type/blobstore.go
@@ -28,8 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
-
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 )
 
@@ -49,15 +47,15 @@ func NewBlobstoreCompactTask() *BlobstoreCompactTask {
 // --------------------------------------------
 // Blobstore Compact Format Functions
 // --------------------------------------------
-func (f *BlobstoreCompactTask) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.TaskXO, *http.Response, error) {
+func (f *BlobstoreCompactTask) DoCreateRequest(plan any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*common.TaskApiModel, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskBlobstoreCompactModel)
 
 	// Call API to Create
-	return apiClient.TasksAPI.CreateTask(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return taskService.CreateTask(ctx, planModel.ToApiCreateModel(version))
 }
 
-func (f *BlobstoreCompactTask) DoUpdateRequest(plan any, state any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *BlobstoreCompactTask) DoUpdateRequest(plan any, state any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskBlobstoreCompactModel)
 
@@ -65,7 +63,7 @@ func (f *BlobstoreCompactTask) DoUpdateRequest(plan any, state any, apiClient *v
 	stateModel := (state).(model.TaskBlobstoreCompactModel)
 
 	// Call API to Update
-	return apiClient.TasksAPI.UpdateTask(ctx, stateModel.Id.ValueString()).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return taskService.UpdateTask(ctx, stateModel.Id.ValueString(), planModel.ToApiUpdateModel(version))
 }
 
 func (f *BlobstoreCompactTask) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {
@@ -98,7 +96,7 @@ func (f *BlobstoreCompactTask) UpdatePlanForState(plan any) any {
 
 func (f *BlobstoreCompactTask) UpdateStateFromApi(state any, api any) any {
 	stateModel := (state).(model.TaskBlobstoreCompactModel)
-	apiModel := (api).(v3.TaskXO)
+	apiModel := (api).(common.TaskApiModel)
 	stateModel.MapFromApi(&apiModel)
 	return stateModel
 }

--- a/internal/provider/task/task_type/common.go
+++ b/internal/provider/task/task_type/common.go
@@ -26,8 +26,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	tfschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
-
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // BaseTaskType that all task types build from
@@ -64,8 +62,8 @@ func (f *BaseTaskType) Type() common.TaskType {
 // TaskTypeI that all Repository Formats must implement
 // --------------------------------------------
 type TaskTypeI interface {
-	DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.TaskXO, *http.Response, error)
-	DoUpdateRequest(plan any, state any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error)
+	DoCreateRequest(plan any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*common.TaskApiModel, *http.Response, error)
+	DoUpdateRequest(plan any, state any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*http.Response, error)
 	ApiCreateSuccessResponseCodes() []int
 	MarkdownDescription() string
 	PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics)

--- a/internal/provider/task/task_type/license.go
+++ b/internal/provider/task/task_type/license.go
@@ -28,8 +28,6 @@ import (
 	tfschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 type LicenseExpirationNotificationTask struct {
@@ -48,15 +46,15 @@ func NewLicenseExpirationNotificationTask() *LicenseExpirationNotificationTask {
 // --------------------------------------------
 // Blobstore Compact Format Functions
 // --------------------------------------------
-func (f *LicenseExpirationNotificationTask) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.TaskXO, *http.Response, error) {
+func (f *LicenseExpirationNotificationTask) DoCreateRequest(plan any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*common.TaskApiModel, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskLicenseExpirationNotificationModel)
 
 	// Call API to Create
-	return apiClient.TasksAPI.CreateTask(ctx).Body(*planModel.ToApiCreateModel()).Execute()
+	return taskService.CreateTask(ctx, planModel.ToApiCreateModel())
 }
 
-func (f *LicenseExpirationNotificationTask) DoUpdateRequest(plan any, state any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *LicenseExpirationNotificationTask) DoUpdateRequest(plan any, state any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskLicenseExpirationNotificationModel)
 
@@ -64,7 +62,7 @@ func (f *LicenseExpirationNotificationTask) DoUpdateRequest(plan any, state any,
 	stateModel := (state).(model.TaskLicenseExpirationNotificationModel)
 
 	// Call API to Update
-	return apiClient.TasksAPI.UpdateTask(ctx, stateModel.Id.ValueString()).Body(*planModel.ToApiUpdateModel()).Execute()
+	return taskService.UpdateTask(ctx, stateModel.Id.ValueString(), planModel.ToApiUpdateModel())
 }
 
 func (f *LicenseExpirationNotificationTask) MarkdownDescription() string {
@@ -98,7 +96,7 @@ func (f *LicenseExpirationNotificationTask) UpdatePlanForState(plan any) any {
 
 func (f *LicenseExpirationNotificationTask) UpdateStateFromApi(state, api any) any {
 	stateModel := (state).(model.TaskLicenseExpirationNotificationModel)
-	apiModel := (api).(v3.TaskXO)
+	apiModel := (api).(common.TaskApiModel)
 	stateModel.MapFromApi(&apiModel)
 	return stateModel
 }

--- a/internal/provider/task/task_type/malware.go
+++ b/internal/provider/task/task_type/malware.go
@@ -29,8 +29,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
-
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 )
 
@@ -53,15 +51,15 @@ func NewMalwareRemediatorTask() *MalwareRemediatorTask {
 // --------------------------------------------
 // Malware Remediators Functions
 // --------------------------------------------
-func (f *MalwareRemediatorTask) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.TaskXO, *http.Response, error) {
+func (f *MalwareRemediatorTask) DoCreateRequest(plan any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*common.TaskApiModel, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskMalwareRemediationModel)
 
 	// Call API to Create
-	return apiClient.TasksAPI.CreateTask(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return taskService.CreateTask(ctx, planModel.ToApiCreateModel(version))
 }
 
-func (f *MalwareRemediatorTask) DoUpdateRequest(plan any, state any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *MalwareRemediatorTask) DoUpdateRequest(plan any, state any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskMalwareRemediationModel)
 
@@ -69,7 +67,7 @@ func (f *MalwareRemediatorTask) DoUpdateRequest(plan any, state any, apiClient *
 	stateModel := (state).(model.TaskMalwareRemediationModel)
 
 	// Call API to Update
-	return apiClient.TasksAPI.UpdateTask(ctx, stateModel.Id.ValueString()).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return taskService.UpdateTask(ctx, stateModel.Id.ValueString(), planModel.ToApiUpdateModel(version))
 }
 
 func (f *MalwareRemediatorTask) MarkdownDescription() string {
@@ -119,7 +117,7 @@ func (f *MalwareRemediatorTask) UpdatePlanForState(plan any) any {
 
 func (f *MalwareRemediatorTask) UpdateStateFromApi(state any, api any) any {
 	stateModel := (state).(model.TaskMalwareRemediationModel)
-	apiModel := (api).(v3.TaskXO)
+	apiModel := (api).(common.TaskApiModel)
 	stateModel.MapFromApi(&apiModel)
 	return stateModel
 }

--- a/internal/provider/task/task_type/repair.go
+++ b/internal/provider/task/task_type/repair.go
@@ -30,8 +30,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
-
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 )
 
@@ -67,15 +65,15 @@ func NewRepairRebuildBrowseNodesTask() *RepairRebuildBrowseNodesTask {
 // --------------------------------------------
 // Repair: Rebuild Repository Browse Nodes Functions
 // --------------------------------------------
-func (f *RepairRebuildBrowseNodesTask) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.TaskXO, *http.Response, error) {
+func (f *RepairRebuildBrowseNodesTask) DoCreateRequest(plan any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*common.TaskApiModel, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskRepairCreateBrowseNodesModel)
 
 	// Call API to Create
-	return apiClient.TasksAPI.CreateTask(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return taskService.CreateTask(ctx, planModel.ToApiCreateModel(version))
 }
 
-func (f *RepairRebuildBrowseNodesTask) DoUpdateRequest(plan any, state any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *RepairRebuildBrowseNodesTask) DoUpdateRequest(plan any, state any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskRepairCreateBrowseNodesModel)
 
@@ -83,7 +81,7 @@ func (f *RepairRebuildBrowseNodesTask) DoUpdateRequest(plan any, state any, apiC
 	stateModel := (state).(model.TaskRepairCreateBrowseNodesModel)
 
 	// Call API to Update
-	return apiClient.TasksAPI.UpdateTask(ctx, stateModel.Id.ValueString()).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return taskService.UpdateTask(ctx, stateModel.Id.ValueString(), planModel.ToApiUpdateModel(version))
 }
 
 func (f *RepairRebuildBrowseNodesTask) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {
@@ -110,7 +108,7 @@ func (f *RepairRebuildBrowseNodesTask) UpdatePlanForState(plan any) any {
 
 func (f *RepairRebuildBrowseNodesTask) UpdateStateFromApi(state any, api any) any {
 	stateModel := (state).(model.TaskRepairCreateBrowseNodesModel)
-	apiModel := (api).(v3.TaskXO)
+	apiModel := (api).(common.TaskApiModel)
 	stateModel.MapFromApi(&apiModel)
 	return stateModel
 }

--- a/internal/provider/task/task_type/repository.go
+++ b/internal/provider/task/task_type/repository.go
@@ -28,8 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
-	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
-
 	"github.com/sonatype-nexus-community/terraform-provider-shared/schema"
 )
 
@@ -52,15 +50,15 @@ func NewRepositoryDockerGcTask() *RepositoryDockerGcTask {
 // --------------------------------------------
 // Docker Repository GC Format Functions
 // --------------------------------------------
-func (f *RepositoryDockerGcTask) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.TaskXO, *http.Response, error) {
+func (f *RepositoryDockerGcTask) DoCreateRequest(plan any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*common.TaskApiModel, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskRepositoryDockerGcModel)
 
 	// Call API to Create
-	return apiClient.TasksAPI.CreateTask(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return taskService.CreateTask(ctx, planModel.ToApiCreateModel(version))
 }
 
-func (f *RepositoryDockerGcTask) DoUpdateRequest(plan any, state any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *RepositoryDockerGcTask) DoUpdateRequest(plan any, state any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskRepositoryDockerGcModel)
 
@@ -68,7 +66,7 @@ func (f *RepositoryDockerGcTask) DoUpdateRequest(plan any, state any, apiClient 
 	stateModel := (state).(model.TaskRepositoryDockerGcModel)
 
 	// Call API to Update
-	return apiClient.TasksAPI.UpdateTask(ctx, stateModel.Id.ValueString()).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return taskService.UpdateTask(ctx, stateModel.Id.ValueString(), planModel.ToApiUpdateModel(version))
 }
 
 func (f *RepositoryDockerGcTask) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {
@@ -99,7 +97,7 @@ func (f *RepositoryDockerGcTask) UpdatePlanForState(plan any) any {
 
 func (f *RepositoryDockerGcTask) UpdateStateFromApi(state any, api any) any {
 	stateModel := (state).(model.TaskRepositoryDockerGcModel)
-	apiModel := (api).(v3.TaskXO)
+	apiModel := (api).(common.TaskApiModel)
 	stateModel.MapFromApi(&apiModel)
 	return stateModel
 }
@@ -133,15 +131,15 @@ func NewRepositoryDockerUploadPurgeTaskTask() *RepositoryDockerUploadPurgeTask {
 // --------------------------------------------
 // Docker Repository GC Format Functions
 // --------------------------------------------
-func (f *RepositoryDockerUploadPurgeTask) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.TaskXO, *http.Response, error) {
+func (f *RepositoryDockerUploadPurgeTask) DoCreateRequest(plan any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*common.TaskApiModel, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskRepositoryDockerUploadPurgeModel)
 
 	// Call API to Create
-	return apiClient.TasksAPI.CreateTask(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return taskService.CreateTask(ctx, planModel.ToApiCreateModel(version))
 }
 
-func (f *RepositoryDockerUploadPurgeTask) DoUpdateRequest(plan any, state any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *RepositoryDockerUploadPurgeTask) DoUpdateRequest(plan any, state any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskRepositoryDockerUploadPurgeModel)
 
@@ -149,7 +147,7 @@ func (f *RepositoryDockerUploadPurgeTask) DoUpdateRequest(plan any, state any, a
 	stateModel := (state).(model.TaskRepositoryDockerUploadPurgeModel)
 
 	// Call API to Update
-	return apiClient.TasksAPI.UpdateTask(ctx, stateModel.Id.ValueString()).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return taskService.UpdateTask(ctx, stateModel.Id.ValueString(), planModel.ToApiUpdateModel(version))
 }
 
 func (f *RepositoryDockerUploadPurgeTask) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {
@@ -179,7 +177,7 @@ func (f *RepositoryDockerUploadPurgeTask) UpdatePlanForState(plan any) any {
 
 func (f *RepositoryDockerUploadPurgeTask) UpdateStateFromApi(state any, api any) any {
 	stateModel := (state).(model.TaskRepositoryDockerUploadPurgeModel)
-	apiModel := (api).(v3.TaskXO)
+	apiModel := (api).(common.TaskApiModel)
 	stateModel.MapFromApi(&apiModel)
 	return stateModel
 }
@@ -213,15 +211,15 @@ func NewRepositoryMavenRemoveSnapshotsTask() *RepositoryMavenRemoveSnapshotsTask
 // --------------------------------------------
 // Maven Repository Remove Snapshots Functions
 // --------------------------------------------
-func (f *RepositoryMavenRemoveSnapshotsTask) DoCreateRequest(plan any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*v3.TaskXO, *http.Response, error) {
+func (f *RepositoryMavenRemoveSnapshotsTask) DoCreateRequest(plan any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*common.TaskApiModel, *http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskRepositoryMavenRemoveSnapshotsModel)
 
 	// Call API to Create
-	return apiClient.TasksAPI.CreateTask(ctx).Body(*planModel.ToApiCreateModel(version)).Execute()
+	return taskService.CreateTask(ctx, planModel.ToApiCreateModel(version))
 }
 
-func (f *RepositoryMavenRemoveSnapshotsTask) DoUpdateRequest(plan any, state any, apiClient *v3.APIClient, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
+func (f *RepositoryMavenRemoveSnapshotsTask) DoUpdateRequest(plan any, state any, taskService common.TaskService, ctx context.Context, version common.SystemVersion) (*http.Response, error) {
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.TaskRepositoryMavenRemoveSnapshotsModel)
 
@@ -229,7 +227,7 @@ func (f *RepositoryMavenRemoveSnapshotsTask) DoUpdateRequest(plan any, state any
 	stateModel := (state).(model.TaskRepositoryMavenRemoveSnapshotsModel)
 
 	// Call API to Update
-	return apiClient.TasksAPI.UpdateTask(ctx, stateModel.Id.ValueString()).Body(*planModel.ToApiUpdateModel(version)).Execute()
+	return taskService.UpdateTask(ctx, stateModel.Id.ValueString(), planModel.ToApiUpdateModel(version))
 }
 
 func (f *RepositoryMavenRemoveSnapshotsTask) PlanAsModel(ctx context.Context, plan tfsdk.Plan) (any, diag.Diagnostics) {
@@ -271,7 +269,7 @@ func (f *RepositoryMavenRemoveSnapshotsTask) UpdatePlanForState(plan any) any {
 
 func (f *RepositoryMavenRemoveSnapshotsTask) UpdateStateFromApi(state any, api any) any {
 	stateModel := (state).(model.TaskRepositoryMavenRemoveSnapshotsModel)
-	apiModel := (api).(v3.TaskXO)
+	apiModel := (api).(common.TaskApiModel)
 	stateModel.MapFromApi(&apiModel)
 	return stateModel
 }

--- a/internal/provider/task/tasks_data_source.go
+++ b/internal/provider/task/tasks_data_source.go
@@ -28,8 +28,6 @@ import (
 
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -76,13 +74,9 @@ func (d *tasksDataSource) Schema(_ context.Context, req datasource.SchemaRequest
 func (d *tasksDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state model.TasksModel
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	tasksResponse, httpResponse, err := d.Client.TasksAPI.GetTasks(ctx).Execute()
+	tasksResponse, httpResponse, err := d.Services.Task.ListTasks(ctx)
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable to list tasks",
@@ -93,10 +87,10 @@ func (d *tasksDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Iterating %d Tasks", len(tasksResponse.Items)))
+	tflog.Debug(ctx, fmt.Sprintf("Iterating %d Tasks", len(tasksResponse)))
 
 	state.Tasks = make([]model.TaskModelSimple, 0)
-	for _, task := range tasksResponse.Items {
+	for _, task := range tasksResponse {
 		tflog.Debug(ctx, fmt.Sprintf("    Processing %s Task", *task.Id))
 		taskModel := model.TaskModelSimple{}
 		taskModel.MapFromApi(&task)

--- a/internal/provider/user/user_resource.go
+++ b/internal/provider/user/user_resource.go
@@ -105,14 +105,10 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Call API to Create
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 	apiBody := sonatyperepo.NewApiCreateUser(plan.Status.ValueString())
 	plan.MapToCreateApi(apiBody)
-	apiResponse, httpResponse, err := r.Client.SecurityManagementUsersAPI.CreateUser(ctx).Body(*apiBody).Execute()
+	apiResponse, httpResponse, err := r.Services.User.CreateUser(ctx, *apiBody)
 
 	if err != nil || httpResponse.StatusCode != http.StatusOK {
 		errors.HandleAPIError(
@@ -145,14 +141,10 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
 	// Read API Call
-	apiResponse, httpResponse, err := r.Client.SecurityManagementUsersAPI.GetUsers(ctx).UserId(state.UserId.ValueString()).Source(state.Source.ValueString()).Execute()
+	apiResponse, httpResponse, err := r.Services.User.GetUsers(ctx, state.UserId.ValueString(), state.Source.ValueString())
 
 	if err != nil {
 		if httpResponse.StatusCode == http.StatusNotFound {
@@ -233,11 +225,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Call API to Update
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 	apiBody := sonatyperepo.NewApiUser(plan.Status.ValueString())
 	plan.MapToApi(apiBody)
 	// Preserve source from state since it's a read-only computed field
@@ -247,7 +235,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		source = common.DEFAULT_USER_SOURCE
 	}
 	apiBody.Source = &source
-	httpResponse, err := r.Client.SecurityManagementUsersAPI.UpdateUser(ctx, state.UserId.ValueString()).Body(*apiBody).Execute()
+	httpResponse, err := r.Services.User.UpdateUser(ctx, state.UserId.ValueString(), *apiBody)
 
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -264,7 +252,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	// If Passowrd is required to be changed, make that additional API call now
 	if !plan.Password.Equal(state.Password) {
-		httpResponse, err = r.Client.SecurityManagementUsersAPI.ChangePassword(ctx, state.UserId.ValueString()).Body(plan.Password.ValueString()).Execute()
+		httpResponse, err = r.Services.User.ChangePassword(ctx, state.UserId.ValueString(), plan.Password.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error updating User password",
@@ -280,7 +268,7 @@ func (r *userResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Refresh state from API to get computed fields
-	apiResponse, httpResponse, err := r.Client.SecurityManagementUsersAPI.GetUsers(ctx).UserId(state.UserId.ValueString()).Source(source).Execute()
+	apiResponse, httpResponse, err := r.Services.User.GetUsers(ctx, state.UserId.ValueString(), source)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading updated User",
@@ -333,13 +321,9 @@ func (r *userResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		r.Auth,
-	)
+	ctx = r.AuthContext(ctx)
 
-	httpResponse, err := r.Client.SecurityManagementUsersAPI.DeleteUser(ctx, state.UserId.ValueString()).Execute()
+	httpResponse, err := r.Services.User.DeleteUser(ctx, state.UserId.ValueString())
 
 	// Handle Error
 	if err != nil {

--- a/internal/provider/user/users_data_source.go
+++ b/internal/provider/user/users_data_source.go
@@ -29,8 +29,6 @@ import (
 
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"terraform-provider-sonatyperepo/internal/provider/model"
-
-	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -86,13 +84,9 @@ func (d *usersDataSource) Schema(_ context.Context, req datasource.SchemaRequest
 func (d *usersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	var state model.UsersModel
 
-	ctx = context.WithValue(
-		ctx,
-		sonatyperepo.ContextBasicAuth,
-		d.Auth,
-	)
+	ctx = d.AuthContext(ctx)
 
-	usersResponse, httpResponse, err := d.Client.SecurityManagementUsersAPI.GetUsers(ctx).Execute()
+	usersResponse, httpResponse, err := d.Services.User.GetUsers(ctx, "", "")
 	if err != nil {
 		errors.HandleAPIError(
 			"Unable to list Users",

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.22.7
+go 1.25.13
 
 require github.com/hashicorp/terraform-plugin-docs v0.21.0
 


### PR DESCRIPTION
Introduces generation-specific service adapters (`internal/provider/common/*_service.go`) so the provider can target both pre-3.94.0 (V382) and 3.94.0+ (V395) NXRM API clients from a single binary, dispatched once per provider configuration based on detected server version.

Fixes surfaced during acceptance testing against live 3.93/3.95 servers:
- `jsonBridge/pruneUnknownJSONFields` now correctly handles the generated client's NullableXxx wrapper pattern and preserves JSON null instead of fabricating zero values.
- `UserService.GetUsers` no longer sends empty-string userId/source as literal query filters, which caused zero results on both NXRM generations.
- `repository_yum.go` no longer applies YumSigning unconditionally.

Also tightens `maven.layout_policy/version_policy` and `alpine.key_pair` to Required, and gives `yum.deploy_policy` a `STRICT` default, matching what Sonatype Nexus Repository actually requires/defaults to server-side. See `CHANGELOG.md` for details.

Resolves:
- #445 
- #449 