### PR TITLE
chore(deps): Bump nexus-repo-api-client-go/v395 to v395.95.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
 	github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3 v3.93.2
-	github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.0
+	github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.2
 	github.com/sonatype-nexus-community/terraform-provider-shared v0.9.4
-	github.com/stretchr/testify v1.11.1
+	github.com/stretchr/testify v1.12.0
 	golang.org/x/text v0.39.0
 )
 
@@ -23,7 +23,6 @@ require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
@@ -53,7 +52,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/oklog/run v1.2.0 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -336,8 +336,6 @@ github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxu
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
-github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -354,8 +352,8 @@ github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnB
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3 v3.93.2 h1:pkLD4Z/oEPth5nlBpWOaXGX+SP89bJLTinoK1p4Jvi4=
 github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3 v3.93.2/go.mod h1:aflMwOI/XkRO3HuXgCVlh+zPFj9KVkDtE1ZwWqJeCm0=
-github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.0 h1:bVr5N4o5dbaA/TVVZKCeAD8etImIgz5b2u9UVKTonbM=
-github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.0/go.mod h1:aa2xZDktuLQ1yLRaVgd8OE7RCf281zYbGN9HPhhjxEg=
+github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.2 h1:/ldM7VZULE/IODRNcO31unsuQXoOhLao25OUnTCQTzY=
+github.com/sonatype-nexus-community/nexus-repo-api-client-go/v395 v395.95.2/go.mod h1:V++qpTYuylrk7k+9dS7NyXqWGBiB8HzN+E43LbszANY=
 github.com/sonatype-nexus-community/terraform-provider-shared v0.9.4 h1:U7pdTOdwl/RS+5Zvz7mUE01XrS5ntONzxD9OmN6ymJw=
 github.com/sonatype-nexus-community/terraform-provider-shared v0.9.4/go.mod h1:WMs2zRL3dPwQj1A9As16dLzVs9jRFJKEHOtNfKeZqjM=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -369,8 +367,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
+github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=

--- a/internal/provider/common/cleanup_policy_service.go
+++ b/internal/provider/common/cleanup_policy_service.go
@@ -89,15 +89,16 @@ func (s *cleanupPolicyServiceV395) Create(ctx context.Context, body sonatyperepo
 }
 
 func (s *cleanupPolicyServiceV395) GetByName(ctx context.Context, name string) (*http.Response, error) {
-	httpResponse, err := s.client.CleanupPoliciesAPI.GetCleanupPolicies(ctx, name).Execute()
+	_, httpResponse, err := s.client.CleanupPoliciesAPI.GetCleanupPolicies(ctx, name).Execute()
 	if err != nil {
 		return httpResponse, err
 	}
 
-	// The API doesn't declare a typed response for this endpoint in either client generation,
-	// so callers manually decode the body into the V382 CleanupPolicyResourceXO shape. V395's
-	// response has an extra 'repositories' field V382's struct doesn't know about, so prune the
-	// raw body down to V382's shape here before the caller ever sees it.
+	// V395 now declares a typed response for this endpoint (as of the client's v395.95.2 release;
+	// v395.95.0/.1 left it untyped), but callers still manually decode the body into the V382
+	// CleanupPolicyResourceXO shape for cross-generation compatibility. V395's response has an
+	// extra 'repositories' field V382's struct doesn't know about, so prune the raw body down to
+	// V382's shape here before the caller ever sees it.
 	body, readErr := io.ReadAll(httpResponse.Body)
 	_ = httpResponse.Body.Close()
 	if readErr != nil {


### PR DESCRIPTION
v395.95.2 corrects the generated OpenAPI client's cleanup policies endpoints: `GetCleanupPolicies`/`ListCleanupPolicies` now return a typed `CleanupPolicyResourceXO` instead of a bare, undecoded `http.Response`. Updates the one call site whose `Execute()` signature changed as a result.