### PR TITLE
fix: Wire NXRM 3.94+ inline firewall support into raw, maven, nuget, conan, conda, ruby_gems proxies

### DIFF
--- a/internal/provider/common/repository_management_service.go
+++ b/internal/provider/common/repository_management_service.go
@@ -79,12 +79,12 @@ type RepositoryManagementService interface {
 	CreateConanHostedRepository(ctx context.Context, body sonatyperepoV382.ConanHostedRepositoryApiRequest) (*http.Response, error)
 	GetConanHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdateConanHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanHostedRepositoryApiRequest) (*http.Response, error)
-	CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error)
-	GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *http.Response, error)
-	UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error)
-	CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error)
-	GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
-	UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error)
+	CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error)
+	UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateDockerGroupRepository(ctx context.Context, body sonatyperepoV382.DockerGroupRepositoryApiRequest) (*http.Response, error)
 	GetDockerGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.DockerGroupApiRepository, *http.Response, error)
 	UpdateDockerGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.DockerGroupRepositoryApiRequest) (*http.Response, error)
@@ -124,9 +124,9 @@ type RepositoryManagementService interface {
 	CreateMavenHostedRepository(ctx context.Context, body sonatyperepoV382.MavenHostedRepositoryApiRequest) (*http.Response, error)
 	GetMavenHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenHostedApiRepository, *http.Response, error)
 	UpdateMavenHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenHostedRepositoryApiRequest) (*http.Response, error)
-	CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error)
-	GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *http.Response, error)
-	UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error)
+	CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateNpmGroupRepository(ctx context.Context, body sonatyperepoV382.NpmGroupRepositoryApiRequest) (*http.Response, error)
 	GetNpmGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupDeployRepository, *http.Response, error)
 	UpdateNpmGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NpmGroupRepositoryApiRequest) (*http.Response, error)
@@ -142,9 +142,9 @@ type RepositoryManagementService interface {
 	CreateNugetHostedRepository(ctx context.Context, body sonatyperepoV382.NugetHostedRepositoryApiRequest) (*http.Response, error)
 	GetNugetHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdateNugetHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetHostedRepositoryApiRequest) (*http.Response, error)
-	CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error)
-	GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *http.Response, error)
-	UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error)
+	CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateP2ProxyRepository(ctx context.Context, body sonatyperepoV382.P2ProxyRepositoryApiRequest) (*http.Response, error)
 	GetP2ProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
 	UpdateP2ProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.P2ProxyRepositoryApiRequest) (*http.Response, error)
@@ -172,18 +172,18 @@ type RepositoryManagementService interface {
 	CreateRawHostedRepository(ctx context.Context, body sonatyperepoV382.RawHostedRepositoryApiRequest) (*http.Response, error)
 	GetRawHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawHostedApiRepository, *http.Response, error)
 	UpdateRawHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawHostedRepositoryApiRequest) (*http.Response, error)
-	CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error)
-	GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *http.Response, error)
-	UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error)
+	CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateRubygemsGroupRepository(ctx context.Context, body sonatyperepoV382.RubyGemsGroupRepositoryApiRequest) (*http.Response, error)
 	GetRubygemsGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiGroupRepository, *http.Response, error)
 	UpdateRubygemsGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsGroupRepositoryApiRequest) (*http.Response, error)
 	CreateRubygemsHostedRepository(ctx context.Context, body sonatyperepoV382.RubyGemsHostedRepositoryApiRequest) (*http.Response, error)
 	GetRubygemsHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiHostedRepository, *http.Response, error)
 	UpdateRubygemsHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsHostedRepositoryApiRequest) (*http.Response, error)
-	CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error)
-	GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
-	UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error)
+	CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error)
+	UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateSwiftGroupRepository(ctx context.Context, body sonatyperepoV382.SwiftGroupRepositoryApiRequest) (*http.Response, error)
 	GetSwiftGroupRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SwiftGroupApiRepository, *http.Response, error)
 	UpdateSwiftGroupRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.SwiftGroupRepositoryApiRequest) (*http.Response, error)
@@ -408,27 +408,29 @@ func (s *repositoryManagementServiceV382) UpdateConanHostedRepository(ctx contex
 	return s.client.RepositoryManagementAPI.UpdateConanHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateConanProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetConanProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetConanProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateConanProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateCondaProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetCondaProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetCondaProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateCondaProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -591,15 +593,16 @@ func (s *repositoryManagementServiceV382) UpdateMavenHostedRepository(ctx contex
 	return s.client.RepositoryManagementAPI.UpdateMavenHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateMavenProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetMavenProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetMavenProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateMavenProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -664,15 +667,16 @@ func (s *repositoryManagementServiceV382) UpdateNugetHostedRepository(ctx contex
 	return s.client.RepositoryManagementAPI.UpdateNugetHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateNugetProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetNugetProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetNugetProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateNugetProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -786,15 +790,16 @@ func (s *repositoryManagementServiceV382) UpdateRawHostedRepository(ctx context.
 	return s.client.RepositoryManagementAPI.UpdateRawHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateRawProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetRawProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetRawProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateRawProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -822,15 +827,16 @@ func (s *repositoryManagementServiceV382) UpdateRubygemsHostedRepository(ctx con
 	return s.client.RepositoryManagementAPI.UpdateRubygemsHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateRubygemsProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetRubygemsProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetRubygemsProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateRubygemsProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -1423,63 +1429,83 @@ func (s *repositoryManagementServiceV395) UpdateConanHostedRepository(ctx contex
 	return s.client.RepositoryManagementAPI.UpdateConanHostedRepository(ctx, repositoryName).ConanHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateConanProxyRepository(ctx context.Context, body sonatyperepoV382.ConanProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.ConanProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateConanProxyRepository(ctx).ConanProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetConanProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.ConanProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetConanProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.ConanProxyApiRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateConanProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ConanProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.ConanProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateConanProxyRepository(ctx, repositoryName).ConanProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateCondaProxyRepository(ctx context.Context, body sonatyperepoV382.CondaProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.CondaProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateCondaProxyRepository(ctx).CondaProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetCondaProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetCondaProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.SimpleApiProxyRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateCondaProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CondaProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.CondaProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateCondaProxyRepository(ctx, repositoryName).CondaProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -1885,33 +1911,43 @@ func (s *repositoryManagementServiceV395) UpdateMavenHostedRepository(ctx contex
 	return s.client.RepositoryManagementAPI.UpdateMavenHostedRepository(ctx, repositoryName).MavenHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateMavenProxyRepository(ctx context.Context, body sonatyperepoV382.MavenProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.MavenProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateMavenProxyRepository(ctx).MavenProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetMavenProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.MavenProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetMavenProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.MavenProxyApiRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateMavenProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.MavenProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.MavenProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateMavenProxyRepository(ctx, repositoryName).MavenProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -2068,33 +2104,43 @@ func (s *repositoryManagementServiceV395) UpdateNugetHostedRepository(ctx contex
 	return s.client.RepositoryManagementAPI.UpdateNugetHostedRepository(ctx, repositoryName).NugetHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateNugetProxyRepository(ctx context.Context, body sonatyperepoV382.NugetProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.NugetProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateNugetProxyRepository(ctx).NugetProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetNugetProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.NugetProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetNugetProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.NugetProxyApiRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateNugetProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.NugetProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.NugetProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateNugetProxyRepository(ctx, repositoryName).NugetProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -2372,30 +2418,39 @@ func (s *repositoryManagementServiceV395) UpdateRawHostedRepository(ctx context.
 	return s.client.RepositoryManagementAPI.UpdateRawHostedRepository(ctx, repositoryName).RawHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateRawProxyRepository(ctx context.Context, body sonatyperepoV382.RawProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.RawProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateRawProxyRepository(ctx).RawProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetRawProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.RawProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRawProxyRepository(ctx, repositoryName).Execute()
 	var result sonatyperepoV382.RawProxyApiRepository
 	if err := bridgeFromResponse(apiV395, httpResponse, err, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	// v395.95.0's RawProxyApiRepository response type has no Firewall field (unlike its
+	// request-type counterpart, and unlike most other proxy formats' response types), so the
+	// mode cannot be read back for Raw via this endpoint.
+	return &result, nil, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateRawProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RawProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.RawProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateRawProxyRepository(ctx, repositoryName).RawProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -2455,33 +2510,43 @@ func (s *repositoryManagementServiceV395) UpdateRubygemsHostedRepository(ctx con
 	return s.client.RepositoryManagementAPI.UpdateRubygemsHostedRepository(ctx, repositoryName).RubyGemsHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateRubygemsProxyRepository(ctx context.Context, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.RubyGemsProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateRubygemsProxyRepository(ctx).RubyGemsProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetRubygemsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetRubygemsProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.SimpleApiProxyRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateRubygemsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.RubyGemsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.RubyGemsProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateRubygemsProxyRepository(ctx, repositoryName).RubyGemsProxyRepositoryApiRequest(v395Body).Execute()
 }
 

--- a/internal/provider/model/repository_raw.go
+++ b/internal/provider/model/repository_raw.go
@@ -92,6 +92,20 @@ type RepositoryRawProxyModel struct {
 
 func (m *RepositoryRawProxyModel) MapMissingApiFieldsFromPlan(planModel RepositoryRawProxyModel) {
 	m.HttpClient.MapMissingApiFieldsFromPlan(planModel.HttpClient)
+
+	// NXRM 3.94+'s Raw proxy repository GET response has no `firewall` field (unlike
+	// its request counterpart), so the inline firewall mode sent on Create/Update can
+	// never be read back. Mirror what was configured in the plan instead - this is the
+	// only source of truth on NXRM 3.94+; on older versions the Capability-based path in
+	// repository_common.go runs afterwards and overwrites this with the real Capability
+	// data. See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/461
+	if planModel.FirewallAuditAndQuarantine != nil {
+		firewall := *planModel.FirewallAuditAndQuarantine
+		firewall.CapabilityId = types.StringNull()
+		m.FirewallAuditAndQuarantine = &firewall
+	} else {
+		m.FirewallAuditAndQuarantine = nil
+	}
 }
 
 func (m *RepositoryRawProxyModel) FromApiModel(api sonatyperepo.RawProxyApiRepository) {

--- a/internal/provider/model/repository_raw_test.go
+++ b/internal/provider/model/repository_raw_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRawProxyMapMissingApiFieldsPreservesFirewallFromPlan verifies that
+// MapMissingApiFieldsFromPlan copies the repository_firewall block from the plan
+// into state. On NXRM 3.94+ the GET response for a Raw proxy repository has no
+// `firewall` field, so this is the only place the value can come from after a
+// Create/Update; failing to do so leaves state's repository_firewall null while
+// the plan has it set, which Terraform reports as "Provider produced inconsistent
+// result after apply" (GitHub issue #461).
+func TestRawProxyMapMissingApiFieldsPreservesFirewallFromPlan(t *testing.T) {
+	// Simulate the state after UpdateStateFromApi: the GET API did not (and
+	// cannot) return repository_firewall, so it is still nil.
+	stateModel := RepositoryRawProxyModel{}
+
+	planModel := RepositoryRawProxyModel{
+		FirewallAuditAndQuarantine: &FirewallAuditAndQuarantineModel{
+			Enabled:    types.BoolValue(true),
+			Quarantine: types.BoolValue(true),
+		},
+	}
+
+	stateModel.MapMissingApiFieldsFromPlan(planModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine, "repository_firewall should be non-nil after MapMissingApiFieldsFromPlan") {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.CapabilityId.IsUnknown(), "capability_id must be known (null) - inline firewall mode has no capability")
+	}
+}
+
+// TestRawProxyMapMissingApiFieldsUpdatesFirewallFromPlan verifies that an
+// existing (non-nil) repository_firewall block in state is replaced with the
+// plan's values, e.g. when a user flips quarantine on for an already-configured
+// repository.
+func TestRawProxyMapMissingApiFieldsUpdatesFirewallFromPlan(t *testing.T) {
+	stateModel := RepositoryRawProxyModel{
+		FirewallAuditAndQuarantine: &FirewallAuditAndQuarantineModel{
+			Enabled:    types.BoolValue(true),
+			Quarantine: types.BoolValue(false),
+		},
+	}
+
+	planModel := RepositoryRawProxyModel{
+		FirewallAuditAndQuarantine: &FirewallAuditAndQuarantineModel{
+			Enabled:    types.BoolValue(true),
+			Quarantine: types.BoolValue(true),
+		},
+	}
+
+	stateModel.MapMissingApiFieldsFromPlan(planModel)
+
+	assert.True(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+}
+
+// TestRawProxyMapMissingApiFieldsNilFirewallInPlan verifies that a nil
+// repository_firewall in the plan (user removed the block) is written to state
+// without a panic.
+func TestRawProxyMapMissingApiFieldsNilFirewallInPlan(t *testing.T) {
+	stateModel := RepositoryRawProxyModel{
+		FirewallAuditAndQuarantine: &FirewallAuditAndQuarantineModel{
+			Enabled:    types.BoolValue(true),
+			Quarantine: types.BoolValue(true),
+		},
+	}
+
+	planModel := RepositoryRawProxyModel{} // FirewallAuditAndQuarantine is nil
+
+	stateModel.MapMissingApiFieldsFromPlan(planModel)
+
+	assert.Nil(t, stateModel.FirewallAuditAndQuarantine)
+}

--- a/internal/provider/repository/format/conan.go
+++ b/internal/provider/repository/format/conan.go
@@ -144,8 +144,11 @@ func (f *ConanRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryConanProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateConanProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateConanProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *ConanRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -153,11 +156,11 @@ func (f *ConanRepositoryFormatProxy) DoReadRequest(state any, apiClient common.R
 	stateModel := (state).(model.RepositoryConanProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetConanProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetConanProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *ConanRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -167,18 +170,21 @@ func (f *ConanRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryConanProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateConanProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateConanProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for Conan Proxy repositories
 func (f *ConanRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetConanProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetConanProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *ConanRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -209,6 +215,27 @@ func (f *ConanRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if state != nil {
 		stateModel = (state).(model.RepositoryConanProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.ConanProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.ConanProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/conda.go
+++ b/internal/provider/repository/format/conda.go
@@ -57,8 +57,11 @@ func (f *CondaRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCondaProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateCondaProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateCondaProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *CondaRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -66,11 +69,11 @@ func (f *CondaRepositoryFormatProxy) DoReadRequest(state any, apiClient common.R
 	stateModel := (state).(model.RepositoryCondaProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetCondaProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetCondaProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *CondaRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -80,18 +83,21 @@ func (f *CondaRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryCondaProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateCondaProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateCondaProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for Conda Proxy repositories
 func (f *CondaRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetCondaProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetCondaProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *CondaRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -120,6 +126,27 @@ func (f *CondaRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if state != nil {
 		stateModel = (state).(model.RepositoryCondaProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.SimpleApiProxyRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/maven.go
+++ b/internal/provider/repository/format/maven.go
@@ -144,8 +144,11 @@ func (f *MavenRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryMavenProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateMavenProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateMavenProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *MavenRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -153,11 +156,11 @@ func (f *MavenRepositoryFormatProxy) DoReadRequest(state any, apiClient common.R
 	stateModel := (state).(model.RepositoryMavenProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetMavenProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetMavenProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *MavenRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -167,18 +170,21 @@ func (f *MavenRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryMavenProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateMavenProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateMavenProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for Maven Proxy repositories
 func (f *MavenRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetMavenProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetMavenProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *MavenRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -209,6 +215,27 @@ func (f *MavenRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if state != nil {
 		stateModel = (state).(model.RepositoryMavenProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.MavenProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.MavenProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/nuget.go
+++ b/internal/provider/repository/format/nuget.go
@@ -143,8 +143,11 @@ func (f *NugetRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryNugetProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateNugetProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateNugetProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *NugetRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -152,11 +155,11 @@ func (f *NugetRepositoryFormatProxy) DoReadRequest(state any, apiClient common.R
 	stateModel := (state).(model.RepositoryNugetProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetNugetProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetNugetProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *NugetRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -166,18 +169,21 @@ func (f *NugetRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiCli
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryNugetProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateNugetProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateNugetProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for NuGet Proxy repositories
 func (f *NugetRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetNugetProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetNugetProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *NugetRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -208,6 +214,27 @@ func (f *NugetRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if state != nil {
 		stateModel = (state).(model.RepositoryNugetProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.NugetProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.NugetProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/proxy_inline_firewall_test.go
+++ b/internal/provider/repository/format/proxy_inline_firewall_test.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"testing"
+
+	"terraform-provider-sonatyperepo/internal/provider/common"
+	"terraform-provider-sonatyperepo/internal/provider/model"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
+)
+
+// TestConanProxyUpdateStateFromApiUnwrapsFirewallMode, and its siblings below, verify that
+// UpdateStateFromApi correctly unwraps a ProxyApiResponseWithFirewall and populates
+// repository_firewall in state. Prior to wiring these formats into the NXRM 3.94+ inline
+// firewall path, DoReadRequest never wrapped its response, so UpdateStateFromApi silently
+// dropped any firewall configuration - the same class of bug reported for Raw in
+// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/461.
+func TestConanProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+	f := &ConanRepositoryFormatProxy{}
+	mode := common.FirewallModeQuarantine
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryConanProxyModel{}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.ConanProxyApiRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryConanProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.CapabilityId.IsNull())
+	}
+}
+
+func TestCondaProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+	f := &CondaRepositoryFormatProxy{}
+	mode := common.FirewallModeAudit
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryCondaProxyModel{}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.SimpleApiProxyRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryCondaProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+	}
+}
+
+func TestMavenProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+	f := &MavenRepositoryFormatProxy{}
+	mode := common.FirewallModeQuarantine
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryMavenProxyModel{}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.MavenProxyApiRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryMavenProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+	}
+}
+
+func TestNugetProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+	f := &NugetRepositoryFormatProxy{}
+	mode := common.FirewallModeDisabled
+
+	// An existing repository_firewall block in state must be cleared when the server
+	// reports the mode as disabled.
+	stateModel := f.UpdateStateFromApi(model.RepositoryNugetProxyModel{
+		FirewallAuditAndQuarantine: model.NewFirewallAuditAndQuarantineModelWithDefaults(),
+	}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.NugetProxyApiRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryNugetProxyModel)
+
+	assert.Nil(t, stateModel.FirewallAuditAndQuarantine)
+}
+
+func TestRubyGemsProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+	f := &RubyGemsRepositoryFormatProxy{}
+	mode := common.FirewallModeAudit
+
+	stateModel := f.UpdateStateFromApi(model.RepositorRubyGemsProxyModel{}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.SimpleApiProxyRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositorRubyGemsProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+	}
+}
+
+// TestRawProxyUpdateStateFromApiUnwrapsFirewallMode mirrors the tests above for Raw. Unlike
+// the other formats, Raw's GetRawProxyRepository always returns a nil FirewallMode (its
+// response type has no `firewall` field - see the comment on that function), so this
+// exercises the defensive branch that would populate repository_firewall if a future client
+// update ever started returning it, without regressing the format's actual fix
+// (MapMissingApiFieldsFromPlan - see repository_raw_test.go) if that ever changes.
+func TestRawProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+	f := &RawRepositoryFormatProxy{}
+	mode := common.FirewallModeQuarantine
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryRawProxyModel{}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.RawProxyApiRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryRawProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+	}
+}
+
+// TestRawProxyUpdateStateFromApiPreservesExistingFirewallWhenModeUnknown covers Raw's actual
+// runtime path: GetRawProxyRepository always wraps with a nil FirewallMode, so
+// UpdateStateFromApi must leave repository_firewall exactly as it came in on state, rather
+// than wiping it - it's MapMissingApiFieldsFromPlan's job (called right after, in both
+// Create and Update) to correct it from the plan.
+func TestRawProxyUpdateStateFromApiPreservesExistingFirewallWhenModeUnknown(t *testing.T) {
+	f := &RawRepositoryFormatProxy{}
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryRawProxyModel{
+		FirewallAuditAndQuarantine: &model.FirewallAuditAndQuarantineModel{
+			Enabled:    types.BoolValue(true),
+			Quarantine: types.BoolValue(true),
+		},
+	}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.RawProxyApiRepository{},
+		FirewallMode: nil,
+	}).(model.RepositoryRawProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+	}
+}

--- a/internal/provider/repository/format/raw.go
+++ b/internal/provider/repository/format/raw.go
@@ -144,8 +144,11 @@ func (f *RawRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.Re
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryRawProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateRawProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateRawProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *RawRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -153,11 +156,11 @@ func (f *RawRepositoryFormatProxy) DoReadRequest(state any, apiClient common.Rep
 	stateModel := (state).(model.RepositoryRawProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetRawProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetRawProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *RawRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -167,18 +170,21 @@ func (f *RawRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClien
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryRawProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateRawProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateRawProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for Raw Proxy repositories
 func (f *RawRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetRawProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetRawProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *RawRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -209,6 +215,30 @@ func (f *RawRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if state != nil {
 		stateModel = (state).(model.RepositoryRawProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path. Raw's GET
+	// response has no `firewall` field though (see GetRawProxyRepository), so FirewallMode
+	// is always nil here - MapMissingApiFieldsFromPlan is what actually populates
+	// repository_firewall for this format.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.RawProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.RawProxyApiRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/ruby_gems.go
+++ b/internal/provider/repository/format/ruby_gems.go
@@ -139,8 +139,11 @@ func (f *RubyGemsRepositoryFormatProxy) DoCreateRequest(plan any, apiClient comm
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositorRubyGemsProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateRubygemsProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateRubygemsProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *RubyGemsRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -148,11 +151,11 @@ func (f *RubyGemsRepositoryFormatProxy) DoReadRequest(state any, apiClient commo
 	stateModel := (state).(model.RepositorRubyGemsProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetRubygemsProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetRubygemsProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *RubyGemsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -162,18 +165,21 @@ func (f *RubyGemsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, api
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositorRubyGemsProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateRubygemsProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateRubygemsProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for RubyGems Proxy repositories
 func (f *RubyGemsRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetRubygemsProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetRubygemsProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *RubyGemsRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -202,6 +208,27 @@ func (f *RubyGemsRepositoryFormatProxy) UpdateStateFromApi(state any, api any) a
 	if state != nil {
 		stateModel = (state).(model.RepositorRubyGemsProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.SimpleApiProxyRepository))
 	return stateModel
 }


### PR DESCRIPTION
Resolves #461.

Repository Firewall configuration for these proxy formats was only ever wired into the legacy Capability API path. On NXRM 3.94+, that path is skipped in favor of the inline `firewall.mode` request/response field, which these formats never sent or read - so a configured `repository_firewall` block was silently dropped on create/update, producing Terraform's "Provider produced inconsistent result after apply" (#461).

Mirrors the existing npm/docker/go/cargo/etc. inline-firewall pattern:
- Create/Update now compute and send the inline firewall mode.
- Get is wired to read it back, except for Raw, whose NXRM 3.95 GET response type has no `firewall` field at all - state is populated from the plan instead via MapMissingApiFieldsFromPlan.

Unit tests cover the state-consistency fix for all 6 formats. Coverage for the "send" half (Create/Update actually forwarding the computed mode to the API client) is left to acceptance tests, which - like the pre-existing firewall acceptance tests noted in #285 - require a live Sonatype IQ Server connection and are not runnable in this environment.