### PR TITLE
fix: Wire NXRM 3.94+ inline firewall support into `yum` and `cocoapods` proxies (#464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 BUG FIXES:
 * Prevent `Provider produced inconsistent result after apply` error when configuring `repository_firewall` against Sonatype Nexus Repository 3.94.0+ for `sonatyperepo_repository_raw_proxy`, `sonatyperepo_repository_maven2_proxy`, `sonatyperepo_repository_nuget_proxy`, `sonatyperepo_repository_conan_proxy`, `sonatyperepo_repository_conda_proxy` and `sonatyperepo_repository_rubygems_proxy` resources [GH-461]
+* `repository_firewall` now correctly hydrates from the live inline `firewall.mode` on `terraform import`/`plan`/`apply` against Sonatype Nexus Repository 3.94.0+ for `sonatyperepo_repository_yum_proxy` and `sonatyperepo_repository_cocoapods_proxy` resources [GH-464]
 
 ## 1.16.0 Aug 19, 2026
 

--- a/internal/provider/common/repository_management_service.go
+++ b/internal/provider/common/repository_management_service.go
@@ -67,9 +67,9 @@ type RepositoryManagementService interface {
 	CreateCargoProxyRepository(ctx context.Context, body sonatyperepoV382.CargoProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	GetCargoProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.CargoProxyApiRepository, *FirewallMode, *http.Response, error)
 	UpdateCargoProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CargoProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
-	CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error)
-	GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error)
-	UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error)
+	CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error)
+	UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	CreateComposerProxyRepository(ctx context.Context, body sonatyperepoV382.ComposerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 	GetComposerProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error)
 	UpdateComposerProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.ComposerProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
@@ -205,9 +205,9 @@ type RepositoryManagementService interface {
 	CreateYumHostedRepository(ctx context.Context, body sonatyperepoV382.YumHostedRepositoryApiRequest) (*http.Response, error)
 	GetYumHostedRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumHostedApiRepository, *http.Response, error)
 	UpdateYumHostedRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumHostedRepositoryApiRequest) (*http.Response, error)
-	CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error)
-	GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *http.Response, error)
-	UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error)
+	CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
+	GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *FirewallMode, *http.Response, error)
+	UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error)
 }
 
 // repositoryManagementServiceV382 implements RepositoryManagementService against NXRM API
@@ -359,15 +359,16 @@ func (s *repositoryManagementServiceV382) UpdateCargoProxyRepository(ctx context
 	return s.client.RepositoryManagementAPI.UpdateCargoProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateCocoapodsProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetCocoapodsProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetCocoapodsProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateCocoapodsProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -924,15 +925,16 @@ func (s *repositoryManagementServiceV382) UpdateYumHostedRepository(ctx context.
 	return s.client.RepositoryManagementAPI.UpdateYumHostedRepository(ctx, repositoryName).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.CreateYumProxyRepository(ctx).Body(body).Execute()
 }
 
-func (s *repositoryManagementServiceV382) GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *http.Response, error) {
-	return s.client.RepositoryManagementAPI.GetYumProxyRepository(ctx, repositoryName).Execute()
+func (s *repositoryManagementServiceV382) GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *FirewallMode, *http.Response, error) {
+	apiResponse, httpResponse, err := s.client.RepositoryManagementAPI.GetYumProxyRepository(ctx, repositoryName).Execute()
+	return apiResponse, nil, httpResponse, err
 }
 
-func (s *repositoryManagementServiceV382) UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV382) UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	return s.client.RepositoryManagementAPI.UpdateYumProxyRepository(ctx, repositoryName).Body(body).Execute()
 }
 
@@ -1303,33 +1305,43 @@ func (s *repositoryManagementServiceV395) UpdateCargoProxyRepository(ctx context
 	return s.client.RepositoryManagementAPI.UpdateCargoProxyRepository(ctx, repositoryName).CargoProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateCocoapodsProxyRepository(ctx context.Context, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.CocoapodsProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateCocoapodsProxyRepository(ctx).CocoapodsProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetCocoapodsProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.SimpleApiProxyRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetCocoapodsProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.SimpleApiProxyRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateCocoapodsProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.CocoapodsProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.CocoapodsProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateCocoapodsProxyRepository(ctx, repositoryName).CocoapodsProxyRepositoryApiRequest(v395Body).Execute()
 }
 
@@ -2750,32 +2762,42 @@ func (s *repositoryManagementServiceV395) UpdateYumHostedRepository(ctx context.
 	return s.client.RepositoryManagementAPI.UpdateYumHostedRepository(ctx, repositoryName).YumHostedRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) CreateYumProxyRepository(ctx context.Context, body sonatyperepoV382.YumProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.YumProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.CreateYumProxyRepository(ctx).YumProxyRepositoryApiRequest(v395Body).Execute()
 }
 
-func (s *repositoryManagementServiceV395) GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *http.Response, error) {
+func (s *repositoryManagementServiceV395) GetYumProxyRepository(ctx context.Context, repositoryName string) (*sonatyperepoV382.YumProxyApiRepository, *FirewallMode, *http.Response, error) {
 	apiV395, httpResponse, err := s.client.RepositoryManagementAPI.GetYumProxyRepository(ctx, repositoryName).Execute()
 	if err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
+	}
+	var firewallMode *FirewallMode
+	if apiV395.Firewall != nil {
+		firewallMode = (*FirewallMode)(apiV395.Firewall.Mode)
 	}
 	var result sonatyperepoV382.YumProxyApiRepository
 	if err := jsonBridge(apiV395, &result); err != nil {
-		return nil, httpResponse, err
+		return nil, nil, httpResponse, err
 	}
-	return &result, httpResponse, nil
+	return &result, firewallMode, httpResponse, nil
 }
 
-func (s *repositoryManagementServiceV395) UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest) (*http.Response, error) {
+func (s *repositoryManagementServiceV395) UpdateYumProxyRepository(ctx context.Context, repositoryName string, body sonatyperepoV382.YumProxyRepositoryApiRequest, firewallMode *FirewallMode) (*http.Response, error) {
 	var v395Body sonatyperepoV395.YumProxyRepositoryApiRequest
 	if err := jsonBridge(body, &v395Body); err != nil {
 		return nil, err
 	}
 	v395Body.RoutingRuleName = body.RoutingRule
+	if firewallMode != nil {
+		v395Body.Firewall = &sonatyperepoV395.FirewallAttributes{Mode: (*string)(firewallMode)}
+	}
 	return s.client.RepositoryManagementAPI.UpdateYumProxyRepository(ctx, repositoryName).YumProxyRepositoryApiRequest(v395Body).Execute()
 }

--- a/internal/provider/repository/format/cocoapods.go
+++ b/internal/provider/repository/format/cocoapods.go
@@ -57,8 +57,11 @@ func (f *CocoaPodsRepositoryFormatProxy) DoCreateRequest(plan any, apiClient com
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryCocoaPodsProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateCocoapodsProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateCocoapodsProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *CocoaPodsRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -66,11 +69,11 @@ func (f *CocoaPodsRepositoryFormatProxy) DoReadRequest(state any, apiClient comm
 	stateModel := (state).(model.RepositoryCocoaPodsProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetCocoapodsProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetCocoapodsProxyRepository(ctx, stateModel.Name.ValueString())
 	if apiResponse == nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *CocoaPodsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -80,18 +83,21 @@ func (f *CocoaPodsRepositoryFormatProxy) DoUpdateRequest(plan any, state any, ap
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryCocoaPodsProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateCocoapodsProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateCocoapodsProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for NPM Proxy repositories
 func (f *CocoaPodsRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetCocoapodsProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetCocoapodsProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *CocoaPodsRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -120,6 +126,27 @@ func (f *CocoaPodsRepositoryFormatProxy) UpdateStateFromApi(state any, api any) 
 	if state != nil {
 		stateModel = (state).(model.RepositoryCocoaPodsProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.SimpleApiProxyRepository))
 	return stateModel
 }

--- a/internal/provider/repository/format/proxy_inline_firewall_test.go
+++ b/internal/provider/repository/format/proxy_inline_firewall_test.go
@@ -27,11 +27,12 @@ import (
 	sonatyperepo "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
-// TestConanProxyUpdateStateFromApiUnwrapsFirewallMode, and its siblings below, verify that
-// UpdateStateFromApi correctly unwraps a ProxyApiResponseWithFirewall and populates
-// repository_firewall in state. Prior to wiring these formats into the NXRM 3.94+ inline
-// firewall path, DoReadRequest never wrapped its response, so UpdateStateFromApi silently
-// dropped any firewall configuration - the same class of bug reported for Raw in
+// TestConanProxyUpdateStateFromApiUnwrapsFirewallMode, and its siblings below (including the
+// Yum and CocoaPods variants further down - see GH-464), verify that UpdateStateFromApi
+// correctly unwraps a ProxyApiResponseWithFirewall and populates repository_firewall in
+// state. Prior to wiring these formats into the NXRM 3.94+ inline firewall path,
+// DoReadRequest never wrapped its response, so UpdateStateFromApi silently dropped any
+// firewall configuration - the same class of bug reported for Raw in
 // https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/461.
 func TestConanProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
 	f := &ConanRepositoryFormatProxy{}
@@ -107,6 +108,37 @@ func TestRubyGemsProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
 	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
 		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
 		assert.False(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+	}
+}
+
+func TestYumProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+	f := &YumRepositoryFormatProxy{}
+	mode := common.FirewallModeAudit
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryYumProxyModel{}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.YumProxyApiRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryYumProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.CapabilityId.IsNull())
+	}
+}
+
+func TestCocoaPodsProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+	f := &CocoaPodsRepositoryFormatProxy{}
+	mode := common.FirewallModeQuarantine
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryCocoaPodsProxyModel{}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.SimpleApiProxyRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryCocoaPodsProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
 	}
 }
 

--- a/internal/provider/repository/format/yum.go
+++ b/internal/provider/repository/format/yum.go
@@ -145,8 +145,11 @@ func (f *YumRepositoryFormatProxy) DoCreateRequest(plan any, apiClient common.Re
 	// Cast to correct Plan Model Type
 	planModel := (plan).(model.RepositoryYumProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.CreateYumProxyRepository(ctx, planModel.ToApiCreateModel())
+	return apiClient.CreateYumProxyRepository(ctx, planModel.ToApiCreateModel(), &firewallMode)
 }
 
 func (f *YumRepositoryFormatProxy) DoReadRequest(state any, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
@@ -154,11 +157,11 @@ func (f *YumRepositoryFormatProxy) DoReadRequest(state any, apiClient common.Rep
 	stateModel := (state).(model.RepositoryYumProxyModel)
 
 	// Call to API to Read
-	apiResponse, httpResponse, err := apiClient.GetYumProxyRepository(ctx, stateModel.Name.ValueString())
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetYumProxyRepository(ctx, stateModel.Name.ValueString())
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, err
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, err
 }
 
 func (f *YumRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClient common.RepositoryManagementService, ctx context.Context) (*http.Response, error) {
@@ -168,18 +171,21 @@ func (f *YumRepositoryFormatProxy) DoUpdateRequest(plan any, state any, apiClien
 	// Cast to correct State Model Type
 	stateModel := (state).(model.RepositoryYumProxyModel)
 
+	// Compute inline firewall mode (NXRM 3.94+); ignored by pre-3.94 service implementations
+	firewallMode := ComputeFirewallMode(f, planModel)
+
 	// Call API to Create
-	return apiClient.UpdateYumProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel())
+	return apiClient.UpdateYumProxyRepository(ctx, stateModel.Name.ValueString(), planModel.ToApiUpdateModel(), &firewallMode)
 }
 
 // DoImportRequest implements the import functionality for YUM Proxy repositories
 func (f *YumRepositoryFormatProxy) DoImportRequest(repositoryName string, apiClient common.RepositoryManagementService, ctx context.Context) (any, *http.Response, error) {
 	// Call to API to Read repository for import
-	apiResponse, httpResponse, err := apiClient.GetYumProxyRepository(ctx, repositoryName)
+	apiResponse, firewallMode, httpResponse, err := apiClient.GetYumProxyRepository(ctx, repositoryName)
 	if err != nil {
 		return nil, httpResponse, err
 	}
-	return *apiResponse, httpResponse, nil
+	return ProxyApiResponseWithFirewall{Repository: *apiResponse, FirewallMode: firewallMode}, httpResponse, nil
 }
 
 func (f *YumRepositoryFormatProxy) FormatSchemaAttributes() map[string]tfschema.Attribute {
@@ -210,6 +216,27 @@ func (f *YumRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if state != nil {
 		stateModel = (state).(model.RepositoryYumProxyModel)
 	}
+
+	// NXRM 3.94+ returns the repository wrapped with its inline firewall mode; use that
+	// directly instead of the Capability-based UpateStateWithCapability path.
+	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
+		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.YumProxyApiRepository))
+		if wrapped.FirewallMode != nil {
+			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+				stateModel.FirewallAuditAndQuarantine = nil
+			} else {
+				if stateModel.FirewallAuditAndQuarantine == nil {
+					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
+				}
+				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
+				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
+				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
+				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
+			}
+		}
+		return stateModel
+	}
+
 	stateModel.FromApiModel((api).(sonatyperepo.YumProxyApiRepository))
 	return stateModel
 }


### PR DESCRIPTION
Missed fixes from #461.

Resolves #464.

yum and cocoapods were the two remaining proxy formats with the same gap already fixed for raw/maven/nuget/conan/conda/ruby_gems in #461: firewall config was silently dropped on create/update, and repository_firewall never hydrated from the live inline firewall.mode on read/import - so terraform plan proposed adding it forever, even when already configured in Nexus.

Confirmed via the vendored v395.95.2 client that both formats' response and request types carry the `firewall` field, so this mirrors the full read/write round-trip already used for maven/nuget/etc. - no plan-copy workaround needed.

A full audit of all 23 proxy formats confirms every format for which repository_firewall applies (17 of them) is now wired into this inline path; the remaining 6 (ansible_galaxy, apt, helm, p2, swift, terraform) correctly have no repository_firewall support at all.

Adds TestYumProxyUpdateStateFromApiUnwrapsFirewallMode and TestCocoaPodsProxyUpdateStateFromApiUnwrapsFirewallMode, following the pattern established for the other 5 formats.