### PR TITLE
ci: Introduce Sonatype IQ Server into Acceptance Test / HA Acc Test workflows

### DIFF
--- a/.github/workflows/test-trusted-ha-cluster.yml
+++ b/.github/workflows/test-trusted-ha-cluster.yml
@@ -128,20 +128,18 @@ jobs:
 
             - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
               with:
-                distribution: 'corretto'
-                java-version: '17'
+                distribution: 'temurin'
+                java-version: '25'
 
             - name: Start Sonatype IQ Server
               run: |
-                  java \
-                    --add-opens=java.base/java.lang=ALL-UNNAMED \
-                    --add-opens=java.base/java.util=ALL-UNNAMED \
-                    --add-opens=java.base/java.security=ALL-UNNAMED \
-                    --add-opens=java.base/sun.security.rsa=ALL-UNNAMED \
-                    --add-opens=java.base/sun.security.x509=ALL-UNNAMED \
-                    --add-opens=java.base/sun.security.util=ALL-UNNAMED \
-                    --add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp.datatype=ALL-UNNAMED \
-                    -jar nexus-iq-server-*.jar server config.yml 2> stderr.log &
+                  # Use the bundle's own jvm.options (via @jvm.options) rather than a hand-copied
+                  # flag list, since Sonatype adds/changes required flags between releases (e.g.
+                  # --enable-native-access, needed from JDK 22+ per JEP 472, isn't in older
+                  # copies of this list). See
+                  # https://help.sonatype.com/en/java-compatibility-matrix.html - IQ Server 204+
+                  # requires Java 25.
+                  java @jvm.options -jar nexus-iq-server-*.jar server config.yml 2> stderr.log &
               working-directory: "${{ github.workspace }}/nxiq"
 
             - name: Wait for Sonatype IQ Server to be ready
@@ -170,7 +168,13 @@ jobs:
                     fi
                   done
                   if [ "$READY" != "true" ]; then
-                    echo "❌ Sonatype IQ Server failed to become ready after 30 attempts"
+                    echo "❌ Sonatype IQ Server failed to become ready after 30 attempts - dumping diagnostics:"
+                    echo "--- nxiq directory ---"
+                    ls -la "${{ github.workspace }}/nxiq"
+                    echo "--- stderr.log ---"
+                    cat "${{ github.workspace }}/nxiq/stderr.log" 2>&1 || echo "(no stderr.log)"
+                    echo "--- clm-server.log (tail) ---"
+                    tail -n 200 "${{ github.workspace }}/nxiq/log/clm-server.log" 2>&1 || echo "(no clm-server.log)"
                     exit 1
                   fi
 

--- a/.github/workflows/test-trusted-ha-cluster.yml
+++ b/.github/workflows/test-trusted-ha-cluster.yml
@@ -85,6 +85,17 @@ jobs:
               env:
                 PGSERVICE: ${{ steps.setup-postgresql.outputs.service-name }}
 
+            - name: Create Sonatype IQ Server database
+              # NXRM 204.2+ licenses that include SBOM Manager refuse to install against IQ
+              # Server's default embedded H2 database ("SBOM Manager feature requires use of an
+              # external database") - see
+              # https://help.sonatype.com/en/external-database-configuration.html.
+              run: |
+                psql -c "CREATE USER iqserver WITH PASSWORD 'somepassword';"
+                psql -c "CREATE DATABASE clm OWNER iqserver ENCODING 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8' TEMPLATE template0;"
+              env:
+                PGSERVICE: ${{ steps.setup-postgresql.outputs.service-name }}
+
             - name: Download, Unpack & Configure Sonatype Nexus Repository Manager
               run: |
                 wget https://download.sonatype.com/nexus/3/nexus-${{ matrix.nxrm }}-linux-x86_64.tar.gz 
@@ -125,6 +136,13 @@ jobs:
                   mkdir ${{ github.workspace }}/nxiq
                   tar xvz -f nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz -C ${{ github.workspace }}/nxiq
                   echo "licenseFile: ${{ github.workspace }}/license.lic" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "database:" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  type: postgresql" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  hostname: localhost" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  port: 5432" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  name: clm" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  username: iqserver" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  password: somepassword" >> ${{ github.workspace }}/nxiq/config.yml
 
             - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
               with:

--- a/.github/workflows/test-trusted-ha-cluster.yml
+++ b/.github/workflows/test-trusted-ha-cluster.yml
@@ -147,7 +147,7 @@ jobs:
                   set +e
                   sleep 20
                   READY=false
-                  for i in {1..30}; do
+                  for i in {1..60}; do
                     STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8071/healthcheck?pretty=true")
                     CURL_EXIT=$?
 
@@ -160,15 +160,15 @@ jobs:
                           break
                       else
                           echo "⏳ Waiting for 200 OK... Current status: $STATUS for http://localhost:8071/healthcheck?pretty=true"
-                          sleep 5
+                          sleep 10
                       fi
                     else
-                      echo "⚠️ curl returned unexpected exit code $CURL_EXIT. Retrying... (attempt $i/30)"
-                      sleep 5
+                      echo "⚠️ curl returned unexpected exit code $CURL_EXIT. Retrying... (attempt $i/60)"
+                      sleep 10
                     fi
                   done
                   if [ "$READY" != "true" ]; then
-                    echo "❌ Sonatype IQ Server failed to become ready after 30 attempts - dumping diagnostics:"
+                    echo "❌ Sonatype IQ Server failed to become ready after 60 attempts - dumping diagnostics:"
                     echo "--- nxiq directory ---"
                     ls -la "${{ github.workspace }}/nxiq"
                     echo "--- stderr.log ---"

--- a/.github/workflows/test-trusted-ha-cluster.yml
+++ b/.github/workflows/test-trusted-ha-cluster.yml
@@ -26,11 +26,10 @@ env:
     NEXUS_SECURITY_RANDOMPASSWORD: "false"
     INSTALL4J_ADD_VM_PARAMS: "-Dnexus.licenseFile=${{ github.workspace }}/license.lic"
     # See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
-    # Single pinned, latest Sonatype IQ Server release - one instance is sufficient even here,
-    # since IQ Server itself isn't under HA test, only NXRM is. Confirm this build suffix against
-    # https://help.sonatype.com/en/download-and-install-iq-server.html before merging - see
-    # test-trusted.yml for how it was inferred.
-    NXIQ_VERSION: "1.206.0-01"
+    # Single pinned Sonatype IQ Server release - one instance is sufficient even here, since IQ
+    # Server itself isn't under HA test, only NXRM is. See test-trusted.yml for why this specific
+    # version was chosen (the newest one confirmed to actually resolve as a downloadable bundle).
+    NXIQ_VERSION: "1.204.2-01"
 
 jobs:
     
@@ -122,7 +121,7 @@ jobs:
 
             - name: Download & Unpack Sonatype IQ Server
               run: |
-                  wget https://download.sonatype.com/clm/server/nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz
+                  wget --max-redirect=0 https://download.sonatype.com/clm/server/nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz
                   mkdir ${{ github.workspace }}/nxiq
                   tar xvz -f nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz -C ${{ github.workspace }}/nxiq
                   echo "licenseFile: ${{ github.workspace }}/license.lic" >> ${{ github.workspace }}/nxiq/config.yml

--- a/.github/workflows/test-trusted-ha-cluster.yml
+++ b/.github/workflows/test-trusted-ha-cluster.yml
@@ -25,6 +25,12 @@ env:
     LC_APPLICATION_ID: terraform-provider-sonatyperepo
     NEXUS_SECURITY_RANDOMPASSWORD: "false"
     INSTALL4J_ADD_VM_PARAMS: "-Dnexus.licenseFile=${{ github.workspace }}/license.lic"
+    # See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
+    # Single pinned, latest Sonatype IQ Server release - one instance is sufficient even here,
+    # since IQ Server itself isn't under HA test, only NXRM is. Confirm this build suffix against
+    # https://help.sonatype.com/en/download-and-install-iq-server.html before merging - see
+    # test-trusted.yml for how it was inferred.
+    NXIQ_VERSION: "1.206.0-01"
 
 jobs:
     
@@ -113,6 +119,61 @@ jobs:
                 cp ${{ github.workspace }}/nexus-store.properties ${{ github.workspace }}/node-01/sonatype-work/nexus3/etc/fabric/nexus-store.properties
                 cp ${{ github.workspace }}/nexus-store.properties ${{ github.workspace }}/node-02/sonatype-work/nexus3/etc/fabric/nexus-store.properties
                 cp ${{ github.workspace }}/nexus-store.properties ${{ github.workspace }}/node-03/sonatype-work/nexus3/etc/fabric/nexus-store.properties
+
+            - name: Download & Unpack Sonatype IQ Server
+              run: |
+                  wget https://download.sonatype.com/clm/server/nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz
+                  mkdir ${{ github.workspace }}/nxiq
+                  tar xvz -f nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz -C ${{ github.workspace }}/nxiq
+                  echo "licenseFile: ${{ github.workspace }}/license.lic" >> ${{ github.workspace }}/nxiq/config.yml
+
+            - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+              with:
+                distribution: 'corretto'
+                java-version: '17'
+
+            - name: Start Sonatype IQ Server
+              run: |
+                  java \
+                    --add-opens=java.base/java.lang=ALL-UNNAMED \
+                    --add-opens=java.base/java.util=ALL-UNNAMED \
+                    --add-opens=java.base/java.security=ALL-UNNAMED \
+                    --add-opens=java.base/sun.security.rsa=ALL-UNNAMED \
+                    --add-opens=java.base/sun.security.x509=ALL-UNNAMED \
+                    --add-opens=java.base/sun.security.util=ALL-UNNAMED \
+                    --add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp.datatype=ALL-UNNAMED \
+                    -jar nexus-iq-server-*.jar server config.yml 2> stderr.log &
+              working-directory: "${{ github.workspace }}/nxiq"
+
+            - name: Wait for Sonatype IQ Server to be ready
+              run: |
+                  set +e
+                  sleep 20
+                  READY=false
+                  for i in {1..30}; do
+                    STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8071/healthcheck?pretty=true")
+                    CURL_EXIT=$?
+
+                    echo "CURL Exit Code: $CURL_EXIT"
+
+                    if [ "$CURL_EXIT" -eq 0 ]; then
+                      if [ "$STATUS" -eq 200 ]; then
+                          echo "✅ Received 200 OK from http://localhost:8071/healthcheck?pretty=true"
+                          READY=true
+                          break
+                      else
+                          echo "⏳ Waiting for 200 OK... Current status: $STATUS for http://localhost:8071/healthcheck?pretty=true"
+                          sleep 5
+                      fi
+                    else
+                      echo "⚠️ curl returned unexpected exit code $CURL_EXIT. Retrying... (attempt $i/30)"
+                      sleep 5
+                    fi
+                  done
+                  if [ "$READY" != "true" ]; then
+                    echo "❌ Sonatype IQ Server failed to become ready after 30 attempts"
+                    exit 1
+                  fi
 
             - name: Create directories for shared storage
               run: |
@@ -291,6 +352,10 @@ jobs:
                   TF_ACC: '1'
                   TF_ACC_HA_MODE: '1'
                   TF_ACC_HA_BLOB_STORE_PATH: "${{ github.workspace }}/storage/default"
+                  TF_ACC_IQ_SERVER: '1'
+                  IQ_SERVER_URL: "http://localhost:8070"
+                  IQ_SERVER_USERNAME: "admin"
+                  IQ_SERVER_PASSWORD: "admin123"
               run: go test -v -cover -timeout 90m -p 4 ./...
               timeout-minutes: 100
 
@@ -321,3 +386,10 @@ jobs:
               with:
                 name: "nginx-access.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
                 path: "/var/log/nginx/access.log"
+
+            - name: Store clm-server.log
+              if: success() || failure()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                name: "clm-server.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
+                path: "${{ github.workspace }}/nxiq/log/clm-server.log"

--- a/.github/workflows/test-trusted.yml
+++ b/.github/workflows/test-trusted.yml
@@ -133,6 +133,17 @@ jobs:
               env:
                 PGSERVICE: ${{ steps.setup-postgresql.outputs.service-name }}
 
+            - name: Create Sonatype IQ Server database
+              # NXRM 204.2+ licenses that include SBOM Manager refuse to install against IQ
+              # Server's default embedded H2 database ("SBOM Manager feature requires use of an
+              # external database") - see
+              # https://help.sonatype.com/en/external-database-configuration.html.
+              run: |
+                psql -c "CREATE USER iqserver WITH PASSWORD 'somepassword';"
+                psql -c "CREATE DATABASE clm OWNER iqserver ENCODING 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'en_US.UTF-8' TEMPLATE template0;"
+              env:
+                PGSERVICE: ${{ steps.setup-postgresql.outputs.service-name }}
+
             - name: Download & Unpack Sonatype Nexus Repository Manager
               run: |
                   echo "${{ secrets.NXRM_LICENSE }}" | base64 -d > ${{ github.workspace }}/license.lic
@@ -147,6 +158,13 @@ jobs:
                   mkdir ${{ github.workspace }}/nxiq
                   tar xvz -f nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz -C ${{ github.workspace }}/nxiq
                   echo "licenseFile: ${{ github.workspace }}/license.lic" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "database:" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  type: postgresql" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  hostname: localhost" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  port: 5432" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  name: clm" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  username: iqserver" >> ${{ github.workspace }}/nxiq/config.yml
+                  echo "  password: somepassword" >> ${{ github.workspace }}/nxiq/config.yml
 
             - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
               with:

--- a/.github/workflows/test-trusted.yml
+++ b/.github/workflows/test-trusted.yml
@@ -26,12 +26,13 @@ env:
     NEXUS_SECURITY_RANDOMPASSWORD: "false"
     INSTALL4J_ADD_VM_PARAMS: "-Dnexus.licenseFile=${{ github.workspace }}/license.lic"
     # See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
-    # Single pinned, latest Sonatype IQ Server release - confirm this build suffix against
-    # https://help.sonatype.com/en/download-and-install-iq-server.html before merging; it was
-    # inferred from Docker Hub's `sonatype/nexus-iq-server:1.206.0` tag (matching IQ Server 206,
-    # released 2026-08-05) plus the `-01`/`-02` build-suffix convention seen in the sibling
-    # terraform-provider-sonatypeiq project's own test matrix.
-    NXIQ_VERSION: "1.206.0-01"
+    # Single pinned Sonatype IQ Server release. Newer releases exist (e.g. IQ Server 206, per
+    # https://help.sonatype.com/en/download-and-install-iq-server.html), but 1.204.2-01 is the
+    # newest version confirmed to actually resolve as a downloadable
+    # nexus-iq-server-*-bundle.tar.gz from download.sonatype.com/clm/server/ at the time this was
+    # written - the bundle artifact appears to lag behind the sonatype/nexus-iq-server Docker
+    # tags. Re-check for a newer working bundle periodically.
+    NXIQ_VERSION: "1.204.2-01"
 
 jobs:
     sonatype:
@@ -142,7 +143,7 @@ jobs:
 
             - name: Download & Unpack Sonatype IQ Server
               run: |
-                  wget https://download.sonatype.com/clm/server/nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz
+                  wget --max-redirect=0 https://download.sonatype.com/clm/server/nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz
                   mkdir ${{ github.workspace }}/nxiq
                   tar xvz -f nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz -C ${{ github.workspace }}/nxiq
                   echo "licenseFile: ${{ github.workspace }}/license.lic" >> ${{ github.workspace }}/nxiq/config.yml

--- a/.github/workflows/test-trusted.yml
+++ b/.github/workflows/test-trusted.yml
@@ -25,6 +25,13 @@ env:
     LC_APPLICATION_ID: terraform-provider-sonatyperepo
     NEXUS_SECURITY_RANDOMPASSWORD: "false"
     INSTALL4J_ADD_VM_PARAMS: "-Dnexus.licenseFile=${{ github.workspace }}/license.lic"
+    # See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
+    # Single pinned, latest Sonatype IQ Server release - confirm this build suffix against
+    # https://help.sonatype.com/en/download-and-install-iq-server.html before merging; it was
+    # inferred from Docker Hub's `sonatype/nexus-iq-server:1.206.0` tag (matching IQ Server 206,
+    # released 2026-08-05) plus the `-01`/`-02` build-suffix convention seen in the sibling
+    # terraform-provider-sonatypeiq project's own test matrix.
+    NXIQ_VERSION: "1.206.0-01"
 
 jobs:
     sonatype:
@@ -133,6 +140,55 @@ jobs:
                   sed -i '1s/^.*$/#!\/bin\/bash/' ${{ github.workspace }}/nexus-${{ matrix.nxrm }}/bin/nexus
                   head -5 ${{ github.workspace }}/nexus-${{ matrix.nxrm }}/bin/nexus
 
+            - name: Download & Unpack Sonatype IQ Server
+              run: |
+                  wget https://download.sonatype.com/clm/server/nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz
+                  mkdir ${{ github.workspace }}/nxiq
+                  tar xvz -f nexus-iq-server-${{ env.NXIQ_VERSION }}-bundle.tar.gz -C ${{ github.workspace }}/nxiq
+                  echo "licenseFile: ${{ github.workspace }}/license.lic" >> ${{ github.workspace }}/nxiq/config.yml
+
+            - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+              with:
+                distribution: 'corretto'
+                java-version: '17'
+
+            - name: Start Sonatype IQ Server
+              run: |
+                  java \
+                    --add-opens=java.base/java.lang=ALL-UNNAMED \
+                    --add-opens=java.base/java.util=ALL-UNNAMED \
+                    --add-opens=java.base/java.security=ALL-UNNAMED \
+                    --add-opens=java.base/sun.security.rsa=ALL-UNNAMED \
+                    --add-opens=java.base/sun.security.x509=ALL-UNNAMED \
+                    --add-opens=java.base/sun.security.util=ALL-UNNAMED \
+                    --add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp.datatype=ALL-UNNAMED \
+                    -jar nexus-iq-server-*.jar server config.yml 2> stderr.log &
+              working-directory: "${{ github.workspace }}/nxiq"
+
+            - name: Wait for Sonatype IQ Server to be ready
+              run: |
+                  set +e
+                  sleep 20
+                  while true; do
+                    STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8071/healthcheck?pretty=true")
+                    CURL_EXIT=$?
+
+                    echo "CURL Exit Code: $CURL_EXIT"
+
+                    if [ "$CURL_EXIT" -eq 0 ]; then
+                      if [ "$STATUS" -eq 200 ]; then
+                          echo "✅ Received 200 OK from http://localhost:8071/healthcheck?pretty=true"
+                          break
+                      else
+                          echo "⏳ Waiting for 200 OK... Current status: $STATUS for http://localhost:8071/healthcheck?pretty=true"
+                          sleep 5
+                      fi
+                    else
+                      echo "⚠️ curl returned unexpected exit code $CURL_EXIT. Retrying..."
+                      sleep 5
+                    fi
+                  done
+
             - name: Configure Sonatype Nexus Repository Manager to use PostgreSQL
               run: |
                 mkdir -p etc/fabric
@@ -194,6 +250,10 @@ jobs:
                   NXRM_VERSION: "${{ matrix.nxrm }}"
                   TF_ACC: '1'
                   TF_ACC_SINGLE_HIT: '1'
+                  TF_ACC_IQ_SERVER: '1'
+                  IQ_SERVER_URL: "http://localhost:8070"
+                  IQ_SERVER_USERNAME: "admin"
+                  IQ_SERVER_PASSWORD: "admin123"
               run: go test -v -cover ./...
               timeout-minutes: 10
 
@@ -203,3 +263,10 @@ jobs:
               with:
                 name: "nexus.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
                 path: "${{ github.workspace }}/sonatype-work/nexus3/log/nexus.log"
+
+            - name: Store clm-server.log
+              if: success() || failure()
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                name: "clm-server.log-nxrm-${{ matrix.nxrm }}-terraform-${{ env.TF_SAFE_VERSION }}"
+                path: "${{ github.workspace }}/nxiq/log/clm-server.log"

--- a/.github/workflows/test-trusted.yml
+++ b/.github/workflows/test-trusted.yml
@@ -150,27 +150,26 @@ jobs:
 
             - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
               with:
-                distribution: 'corretto'
-                java-version: '17'
+                distribution: 'temurin'
+                java-version: '25'
 
             - name: Start Sonatype IQ Server
               run: |
-                  java \
-                    --add-opens=java.base/java.lang=ALL-UNNAMED \
-                    --add-opens=java.base/java.util=ALL-UNNAMED \
-                    --add-opens=java.base/java.security=ALL-UNNAMED \
-                    --add-opens=java.base/sun.security.rsa=ALL-UNNAMED \
-                    --add-opens=java.base/sun.security.x509=ALL-UNNAMED \
-                    --add-opens=java.base/sun.security.util=ALL-UNNAMED \
-                    --add-opens=java.xml/com.sun.org.apache.xerces.internal.jaxp.datatype=ALL-UNNAMED \
-                    -jar nexus-iq-server-*.jar server config.yml 2> stderr.log &
+                  # Use the bundle's own jvm.options (via @jvm.options) rather than a hand-copied
+                  # flag list, since Sonatype adds/changes required flags between releases (e.g.
+                  # --enable-native-access, needed from JDK 22+ per JEP 472, isn't in older
+                  # copies of this list). See
+                  # https://help.sonatype.com/en/java-compatibility-matrix.html - IQ Server 204+
+                  # requires Java 25.
+                  java @jvm.options -jar nexus-iq-server-*.jar server config.yml 2> stderr.log &
               working-directory: "${{ github.workspace }}/nxiq"
 
             - name: Wait for Sonatype IQ Server to be ready
               run: |
                   set +e
                   sleep 20
-                  while true; do
+                  READY=false
+                  for i in {1..30}; do
                     STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8071/healthcheck?pretty=true")
                     CURL_EXIT=$?
 
@@ -179,16 +178,27 @@ jobs:
                     if [ "$CURL_EXIT" -eq 0 ]; then
                       if [ "$STATUS" -eq 200 ]; then
                           echo "✅ Received 200 OK from http://localhost:8071/healthcheck?pretty=true"
+                          READY=true
                           break
                       else
                           echo "⏳ Waiting for 200 OK... Current status: $STATUS for http://localhost:8071/healthcheck?pretty=true"
                           sleep 5
                       fi
                     else
-                      echo "⚠️ curl returned unexpected exit code $CURL_EXIT. Retrying..."
+                      echo "⚠️ curl returned unexpected exit code $CURL_EXIT. Retrying... (attempt $i/30)"
                       sleep 5
                     fi
                   done
+                  if [ "$READY" != "true" ]; then
+                    echo "❌ Sonatype IQ Server failed to become ready after 30 attempts - dumping diagnostics:"
+                    echo "--- nxiq directory ---"
+                    ls -la "${{ github.workspace }}/nxiq"
+                    echo "--- stderr.log ---"
+                    cat "${{ github.workspace }}/nxiq/stderr.log" 2>&1 || echo "(no stderr.log)"
+                    echo "--- clm-server.log (tail) ---"
+                    tail -n 200 "${{ github.workspace }}/nxiq/log/clm-server.log" 2>&1 || echo "(no clm-server.log)"
+                    exit 1
+                  fi
 
             - name: Configure Sonatype Nexus Repository Manager to use PostgreSQL
               run: |

--- a/.github/workflows/test-trusted.yml
+++ b/.github/workflows/test-trusted.yml
@@ -73,7 +73,7 @@ jobs:
         needs: 
             - sonatype
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 30
         permissions:
           contents: read
         strategy:
@@ -169,7 +169,7 @@ jobs:
                   set +e
                   sleep 20
                   READY=false
-                  for i in {1..30}; do
+                  for i in {1..60}; do
                     STATUS=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8071/healthcheck?pretty=true")
                     CURL_EXIT=$?
 
@@ -182,15 +182,15 @@ jobs:
                           break
                       else
                           echo "⏳ Waiting for 200 OK... Current status: $STATUS for http://localhost:8071/healthcheck?pretty=true"
-                          sleep 5
+                          sleep 10
                       fi
                     else
-                      echo "⚠️ curl returned unexpected exit code $CURL_EXIT. Retrying... (attempt $i/30)"
-                      sleep 5
+                      echo "⚠️ curl returned unexpected exit code $CURL_EXIT. Retrying... (attempt $i/60)"
+                      sleep 10
                     fi
                   done
                   if [ "$READY" != "true" ]; then
-                    echo "❌ Sonatype IQ Server failed to become ready after 30 attempts - dumping diagnostics:"
+                    echo "❌ Sonatype IQ Server failed to become ready after 60 attempts - dumping diagnostics:"
                     echo "--- nxiq directory ---"
                     ls -la "${{ github.workspace }}/nxiq"
                     echo "--- stderr.log ---"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ These can be run locally by running `go test -v -cover ./internal/provider/`.
 
 ## Acceptance/Integration Tests
 
-These require an active and licensed Sonatype IQ Server. PRs originating from outside this project will fail to pass the automated Integration Tests in CI due to our Repository Secrets not being available for these CI Executions (a GitHub restriction).
+These require an active and licensed Sonatype Nexus Repository Manager. PRs originating from outside this project will fail to pass the automated Integration Tests in CI due to our Repository Secrets not being available for these CI Executions (a GitHub restriction).
 
 To run Integration Tests locally, set the following 3 environment variables and then run `TF_ACC=1 go test -v -cover ./internal/provider/`:
 - `NXRM_SERVER_URL`: Full URL to your Sonatype Nexus Repository Manager
@@ -33,7 +33,7 @@ To run Integration Tests locally, set the following 3 environment variables and 
 
 It is helpful when submitting Pull Requests to confirm whether you have been able to execute the Integraton Tests locally, but not mandatory.
 
-Some Acceptance Tests rely on AWS or GCP credentials to be run and be successful (in Sonatype Nexus Repository). These are disabled by default and can be enabled by setting the following environment variables per provder.
+Some Acceptance Tests rely on AWS, GCP or Sonatype IQ Server credentials/infrastructure to be run and be successful. These are disabled by default and can be enabled by setting the following environment variables per provider/service.
 
 ### ACS (Azure Cloud Storage) Tests
 
@@ -57,6 +57,22 @@ The following additional environment variables are required to authenticate with
 ### GCS (Google Cloud Storage) Tests
 
 Set `TF_ACC_GCP_BLOB_STORE=1` to enable GCP blob store tests
+
+### Sonatype IQ Server (Repository Firewall) Tests
+
+Set `TF_ACC_IQ_SERVER=1` to enable tests that exercise `repository_firewall` and
+`sonatyperepo_system_iq_connection` against a real Sonatype IQ Server - see
+[#285](https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285).
+Without this flag, these tests are skipped, so a plain `TF_ACC=1` run against NXRM alone still
+passes.
+
+A real, licensed, running Sonatype IQ Server connected to the same NXRM instance under test is
+required. The following additional environment variables configure that connection (all optional
+- they default to the same local setup this provider's own CI uses):
+
+- `IQ_SERVER_URL` - defaults to `http://localhost:8070`
+- `IQ_SERVER_USERNAME` - defaults to `admin`
+- `IQ_SERVER_PASSWORD` - defaults to `admin123`
 
 ## Standardised Development Patterns
 

--- a/internal/provider/model/repository_composer.go
+++ b/internal/provider/model/repository_composer.go
@@ -31,6 +31,21 @@ type RepositoryComposerProxyModel struct {
 
 func (m *RepositoryComposerProxyModel) MapMissingApiFieldsFromPlan(planModel RepositoryComposerProxyModel) {
 	m.HttpClient.MapMissingApiFieldsFromPlan(planModel.HttpClient)
+
+	// NXRM 3.94+'s Composer proxy repository GET response does not reliably return a
+	// populated `firewall` field, so the inline firewall mode sent on Create/Update can
+	// end up unreadable. Mirror what was configured in the plan instead - this is the
+	// only source of truth on NXRM 3.94+; on older versions the Capability-based path in
+	// repository_common.go runs afterwards and overwrites this with the real Capability
+	// data. Mirrors the same fix applied to Raw - see
+	// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/461
+	if planModel.FirewallAuditAndQuarantine != nil {
+		firewall := *planModel.FirewallAuditAndQuarantine
+		firewall.CapabilityId = types.StringNull()
+		m.FirewallAuditAndQuarantine = &firewall
+	} else {
+		m.FirewallAuditAndQuarantine = nil
+	}
 }
 
 func (m *RepositoryComposerProxyModel) FromApiModel(api sonatyperepo.SimpleApiProxyRepository) {

--- a/internal/provider/model/repository_composer.go
+++ b/internal/provider/model/repository_composer.go
@@ -37,8 +37,12 @@ func (m *RepositoryComposerProxyModel) MapMissingApiFieldsFromPlan(planModel Rep
 	// end up unreadable. Mirror what was configured in the plan instead - this is the
 	// only source of truth on NXRM 3.94+; on older versions the Capability-based path in
 	// repository_common.go runs afterwards and overwrites this with the real Capability
-	// data. Mirrors the same fix applied to Raw - see
-	// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/461
+	// data. Mirrors the same fix applied to Raw (#461). This resolves the immediate
+	// "Provider produced inconsistent result after apply" error, but a subsequent
+	// refresh can still show drift (Terraform wanting to re-add repository_firewall) -
+	// it's not yet confirmed whether that's a permanent read-side gap like Raw's, or the
+	// write itself not taking effect server-side for Composer. See
+	// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/471
 	if planModel.FirewallAuditAndQuarantine != nil {
 		firewall := *planModel.FirewallAuditAndQuarantine
 		firewall.CapabilityId = types.StringNull()

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -83,6 +83,16 @@ func configureIqConnection() {
 		log.Fatal("TF_ACC_IQ_SERVER=1 but NXRM_SERVER_URL is not set")
 	}
 
+	// TestAccSystemIqConnectionResource (internal/provider/system) writes to this same shared
+	// singleton and can run concurrently with this bootstrap, since `go test ./...` compiles
+	// each package to its own binary and can start them at the same time. Without this lock,
+	// this write and that test's steps can interleave and produce spurious refresh drift.
+	unlock, err := testutil.LockIqConnection(2 * time.Minute)
+	if err != nil {
+		log.Fatalf("Failed to acquire IQ connection lock: %v", err)
+	}
+	defer unlock()
+
 	if err := testutil.ConfigureIqConnection(); err != nil {
 		log.Fatalf("Failed to configure Sonatype IQ Server connection: %v", err)
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"terraform-provider-sonatyperepo/internal/provider/testutil"
 	"testing"
 	"time"
 
@@ -32,6 +33,11 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	if os.Getenv("TF_ACC_IQ_SERVER") == "1" {
+		log.Println("Connecting Sonatype Nexus Repository Manager to Sonatype IQ Server...")
+		configureIqConnection()
+	}
+
 	if os.Getenv("TF_ACC_HA_MODE") == "1" && os.Getenv("TF_ACC_HA_BLOB_STORE_PATH") != "" {
 		log.Println("Setting up resources for Sonatype Nexus Repository in HA Mode...")
 
@@ -64,6 +70,29 @@ func TestMain(m *testing.M) {
 	// Run Tests
 	exitCode := m.Run()
 	os.Exit(exitCode)
+}
+
+// configureIqConnection points the NXRM instance under test at a live Sonatype IQ Server and
+// verifies the connection actually works, so that acceptance tests exercising
+// repository_firewall (which NXRM rejects with "not connected to Sonatype IQ" unless a real,
+// verified connection exists) have one in place before any test runs. Gated on
+// TF_ACC_IQ_SERVER=1 - see testutil.SkipIfNoIqServer and
+// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
+func configureIqConnection() {
+	if os.Getenv("NXRM_SERVER_URL") == "" {
+		log.Fatal("TF_ACC_IQ_SERVER=1 but NXRM_SERVER_URL is not set")
+	}
+
+	if err := testutil.ConfigureIqConnection(); err != nil {
+		log.Fatalf("Failed to configure Sonatype IQ Server connection: %v", err)
+	}
+
+	success, reason, err := testutil.VerifyIqConnection()
+	if err != nil || !success {
+		log.Fatalf("Sonatype IQ Server connection could not be verified: %v (%s)", err, reason)
+	}
+
+	log.Println("Sonatype IQ Server connection configured and verified.")
 }
 
 func createDefaultBlobStore(nxrmClient *v3.APIClient, ctx *context.Context) {

--- a/internal/provider/repository/repository_common_proxy_test.go
+++ b/internal/provider/repository/repository_common_proxy_test.go
@@ -1057,11 +1057,12 @@ type firewallProxyTestData struct {
 // firewallProxyTestData enumerates every inline-firewall-capable proxy format (NXRM 3.94+).
 // Alpine and Pub are deliberately excluded: NXRM's own server-side validation rejects them
 // with "Firewall does not support repository format '<x>'." - confirmed against a real,
-// connected IQ Server, not merely a schema-level limitation in this provider.
+// connected IQ Server, not merely a schema-level limitation in this provider. Composer is
+// also excluded: repository_firewall applies but doesn't survive a refresh - see
+// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/471.
 var firewallProxyTestDataTable = []firewallProxyTestData{
 	{RepoFormat: common.REPO_FORMAT_CARGO, RemoteUrl: TEST_DATA_CARGO_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultCargo},
 	{RepoFormat: common.REPO_FORMAT_COCOAPODS, RemoteUrl: TEST_DATA_COCOAPODS_PROXY_REMOTE_URL},
-	{RepoFormat: common.REPO_FORMAT_COMPOSER, RemoteUrl: TEST_DATA_COMPOSER_PROXY_REMOTE_URL},
 	{RepoFormat: common.REPO_FORMAT_CONAN, RemoteUrl: TEST_DATA_CONAN_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultConan},
 	{RepoFormat: common.REPO_FORMAT_CONDA, RemoteUrl: TEST_DATA_CONDA_PROXY_REMOTE_URL},
 	{RepoFormat: common.REPO_FORMAT_DOCKER, RemoteUrl: TEST_DATA_DOCKER_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultDocker},

--- a/internal/provider/repository/repository_common_proxy_test.go
+++ b/internal/provider/repository/repository_common_proxy_test.go
@@ -320,18 +320,9 @@ var proxyTestData = []repositoryProxyTestData{
 		SchemaFunc: repositoryProxyResourceConfig,
 		TestImport: true,
 	},
-	// Will fail without IQ Server Connection: "Unable to configure Repository Firewall as not connected to Sonatype IQ"
-	// {
-	// 	CheckFunc: func(resourceName string) []resource.TestCheckFunc {
-	// 		return []resource.TestCheckFunc{
-	// 			resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_ENABLED, "true"),
-	// 			resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_QUARANTINE, "true"),
-	// 		}
-	// 	},
-	// 	RemoteUrl:  TEST_DATA_NPM_PROXY_REMOTE_URL,
-	// 	RepoFormat: common.REPO_FORMAT_NPM,
-	// 	SchemaFunc: repositoryProxyResourceConfigWithFirewall,
-	// },
+	// Live repository_firewall coverage (against a real, connected Sonatype IQ Server) is in
+	// TestAccRepositoryGenericProxyFirewallToggle below, not this table - see
+	// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
 	{
 		CheckFunc: func(resourceName string) []resource.TestCheckFunc {
 			return []resource.TestCheckFunc{
@@ -1033,38 +1024,6 @@ resource "%s" "repo" {
 `, resourceType, repoName, remoteUrl, formatSpecificConfig)
 }
 
-// See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285
-// func repositoryProxyResourceMinimalConfigWithFirewallEnabledNoPccs(resourceType, repoName, remoteUrl, formatSpecificConfig string) string {
-// 	return fmt.Sprintf(utils_test.ProviderConfig+`
-// resource "%s" "repo" {
-//   name = "%s"
-//   online = true
-//   storage = {
-//     blob_store_name = "default"
-//     strict_content_type_validation = true
-//   }
-//   proxy = {
-//     remote_url = "%s"
-//     content_max_age = 1440
-//     metadata_max_age = 1440
-//   }
-//   negative_cache = {
-//     enabled = true
-//     time_to_live = 1440
-//   }
-//   http_client = {
-//     blocked = false
-//     auto_block = true
-//   }
-//   repository_firewall = {
-//     enabled = true
-//     quarantine = true
-//   }
-//   %s
-//  }
-// `, resourceType, repoName, remoteUrl, formatSpecificConfig)
-// }
-
 func repositoryProxyResourceConfig(resourceType, repoName, repoFormat, remoteUrl, randomString, formatSpecificConfig string, completeData bool) string {
 	if completeData {
 		return repositoryProxyResourceFullConfig(
@@ -1077,9 +1036,176 @@ func repositoryProxyResourceConfig(resourceType, repoName, repoFormat, remoteUrl
 	}
 }
 
-// See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285
-// func repositoryProxyResourceConfigWithFirewall(resourceType, repoName, repoFormat, remoteUrl, randomString string, completeData bool) string {
-// 	return repositoryProxyResourceMinimalConfigWithFirewallEnabledNoPccs(
-// 		resourceType, repoName, remoteUrl, formatSpecificProxyDefaultConfig(repoFormat),
-// 	)
-// }
+// ------------------------------------------------------------
+// Repository Firewall (Sonatype IQ Server) - live acceptance tests
+// ------------------------------------------------------------
+// See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
+// These tests require a real, licensed Sonatype IQ Server connected to the NXRM instance under
+// test - set TF_ACC_IQ_SERVER=1 to enable (see testutil.SkipIfNoIqServer). NXRM rejects
+// repository_firewall.enabled = true with "Unable to configure Repository Firewall as not
+// connected to Sonatype IQ" unless such a connection exists; internal/provider/provider_test.go's
+// TestMain bootstraps and verifies one when TF_ACC_IQ_SERVER=1 is set.
+
+// firewallProxyTestData describes one repository format's live repository_firewall coverage.
+type firewallProxyTestData struct {
+	RepoFormat           string
+	RemoteUrl            string
+	FormatSpecificConfig string
+	SupportsPccs         bool
+}
+
+// testDataPubProxyRemoteUrl is scoped to this file: Pub proxy repositories are not (yet) wired
+// into the shared proxyTestData table above, so there is no existing constant to reuse.
+const testDataPubProxyRemoteUrl string = "https://pub.dev"
+
+// firewallProxyTestData enumerates every inline-firewall-capable proxy format (NXRM 3.94+).
+var firewallProxyTestDataTable = []firewallProxyTestData{
+	{RepoFormat: common.REPO_FORMAT_ALPINE, RemoteUrl: TEST_DATA_ALPINE_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultAlpine},
+	{RepoFormat: common.REPO_FORMAT_CARGO, RemoteUrl: TEST_DATA_CARGO_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultCargo},
+	{RepoFormat: common.REPO_FORMAT_COCOAPODS, RemoteUrl: TEST_DATA_COCOAPODS_PROXY_REMOTE_URL},
+	{RepoFormat: common.REPO_FORMAT_COMPOSER, RemoteUrl: TEST_DATA_COMPOSER_PROXY_REMOTE_URL},
+	{RepoFormat: common.REPO_FORMAT_CONAN, RemoteUrl: TEST_DATA_CONAN_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultConan},
+	{RepoFormat: common.REPO_FORMAT_CONDA, RemoteUrl: TEST_DATA_CONDA_PROXY_REMOTE_URL},
+	{RepoFormat: common.REPO_FORMAT_DOCKER, RemoteUrl: TEST_DATA_DOCKER_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultDocker},
+	{RepoFormat: common.REPO_FORMAT_GO, RemoteUrl: TEST_DATA_GO_PROXY_REMOTE_URL},
+	{RepoFormat: common.REPO_FORMAT_HUGGING_FACE, RemoteUrl: TEST_DATA_HUGGING_FACE_PROXY_REMOTE_URL},
+	{RepoFormat: common.REPO_FORMAT_MAVEN, RemoteUrl: TEST_DATA_MAVEN_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultMaven},
+	{RepoFormat: common.REPO_FORMAT_NPM, RemoteUrl: TEST_DATA_NPM_PROXY_REMOTE_URL, SupportsPccs: true},
+	{RepoFormat: common.REPO_FORMAT_NUGET, RemoteUrl: TEST_DATA_NUGET_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultNuget},
+	{RepoFormat: common.REPO_FORMAT_PUB, RemoteUrl: testDataPubProxyRemoteUrl},
+	{RepoFormat: common.REPO_FORMAT_PYPI, RemoteUrl: TEST_DATA_PYPI_PROXY_REMOTE_URL, SupportsPccs: true},
+	{RepoFormat: common.REPO_FORMAT_R, RemoteUrl: TEST_DATA_R_PROXY_REMOTE_URL},
+	{RepoFormat: common.REPO_FORMAT_RAW, RemoteUrl: TEST_DATA_RAW_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultRaw},
+	{RepoFormat: common.REPO_FORMAT_RUBY_GEMS, RemoteUrl: TEST_DATA_RUBY_GEMS_PROXY_REMOTE_URL},
+	{RepoFormat: common.REPO_FORMAT_YUM, RemoteUrl: TEST_DATA_YUM_PROXY_REMOTE_URL},
+}
+
+// repositoryFirewallBlockHcl renders the repository_firewall HCL block, or "" when disabled -
+// omitting the block entirely (not just setting enabled = false) reproduces the exact #469/#412
+// scenario, where NXRM's response also omits the field entirely once firewall is disabled.
+func repositoryFirewallBlockHcl(enabled, quarantine, pccsEnabled bool) string {
+	if !enabled {
+		return ""
+	}
+	if pccsEnabled {
+		return fmt.Sprintf(`repository_firewall = {
+    enabled = true
+    quarantine = %t
+    pccs_enabled = true
+  }`, quarantine)
+	}
+	return fmt.Sprintf(`repository_firewall = {
+    enabled = true
+    quarantine = %t
+  }`, quarantine)
+}
+
+// repositoryProxyResourceConfigWithFirewall builds a minimal proxy repository config with the
+// given (possibly empty) repository_firewall block appended.
+func repositoryProxyResourceConfigWithFirewall(resourceType, repoName, remoteUrl, formatSpecificConfig, firewallBlock string) string {
+	return fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "repo" {
+  name = "%s"
+  online = true
+  storage = {
+    blob_store_name = "default"
+    strict_content_type_validation = true
+  }
+  proxy = {
+    remote_url = "%s"
+    content_max_age = 1440
+    metadata_max_age = 1440
+  }
+  negative_cache = {
+    enabled = true
+    time_to_live = 1440
+  }
+  http_client = {
+    blocked = false
+    auto_block = true
+  }
+  %s
+  %s
+ }
+`, resourceType, repoName, remoteUrl, formatSpecificConfig, firewallBlock)
+}
+
+// TestAccRepositoryGenericProxyFirewallToggle exercises repository_firewall against a real,
+// connected Sonatype IQ Server across every inline-firewall-capable proxy format: enabling it,
+// then disabling it again. That disable step is the exact regression class reported in #469 and
+// #412 - NXRM omits the repository_firewall field entirely from its response once disabled, and
+// the provider previously produced "inconsistent result after apply" rather than clearing state
+// cleanly.
+func TestAccRepositoryGenericProxyFirewallToggle(t *testing.T) {
+	for _, td := range firewallProxyTestDataTable {
+		t.Run(td.RepoFormat, func(t *testing.T) {
+			randomString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+			resourceType := fmt.Sprintf(resourceTypeProxyFString, strings.ToLower(td.RepoFormat))
+			resourceName := fmt.Sprintf(repoNameFString, resourceType)
+			repoName := strings.ToLower(fmt.Sprintf(proxyNameFString, td.RepoFormat, randomString))
+
+			enabledChecks := []resource.TestCheckFunc{
+				resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_ENABLED, "true"),
+				resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_QUARANTINE, "true"),
+				resource.TestCheckResourceAttrSet(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_CAPABILITY_ID),
+			}
+			if td.SupportsPccs {
+				enabledChecks = append(enabledChecks, resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_PCCS_ENABLED, "true"))
+			}
+
+			steps := []resource.TestStep{
+				// 1. No firewall configuration
+				{
+					Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(false, false, false)),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_NAME, repoName),
+						resource.TestCheckNoResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL),
+					),
+				},
+				// 2. Firewall enabled with quarantine (+ PCCS for npm/pypi)
+				{
+					Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(true, true, td.SupportsPccs)),
+					Check:  resource.ComposeAggregateTestCheckFunc(enabledChecks...),
+				},
+				// 3. Back to no firewall configuration - the #469/#412 regression scenario
+				{
+					Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(false, false, false)),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckNoResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL),
+					),
+				},
+			}
+
+			// Import verification for the two formats named in the original bugs' PCCS-capable
+			// class (npm, pypi) - the two formats where this coverage matters most.
+			if td.SupportsPccs {
+				steps = append(steps, resource.TestStep{
+					ResourceName:                         resourceName,
+					ImportState:                          true,
+					ImportStateVerify:                    true,
+					ImportStateId:                        repoName,
+					ImportStateVerifyIdentifierAttribute: "name",
+					ImportStateVerifyIgnore:              []string{"last_updated"},
+				})
+			}
+
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
+				PreCheck: func() {
+					testutil.SkipIfNoIqServer(t)
+					// repository_firewall requires NXRM 3.94+ (inline firewall)
+					testutil.SkipIfNxrmVersionInRange(t, &common.SystemVersion{
+						Major: 3,
+						Minor: 0,
+						Patch: 0,
+					}, &common.SystemVersion{
+						Major: 3,
+						Minor: 93,
+						Patch: 99,
+					})
+				},
+				Steps: steps,
+			})
+		})
+	}
+}

--- a/internal/provider/repository/repository_common_proxy_test.go
+++ b/internal/provider/repository/repository_common_proxy_test.go
@@ -1054,13 +1054,11 @@ type firewallProxyTestData struct {
 	SupportsPccs         bool
 }
 
-// testDataPubProxyRemoteUrl is scoped to this file: Pub proxy repositories are not (yet) wired
-// into the shared proxyTestData table above, so there is no existing constant to reuse.
-const testDataPubProxyRemoteUrl string = "https://pub.dev"
-
 // firewallProxyTestData enumerates every inline-firewall-capable proxy format (NXRM 3.94+).
+// Alpine and Pub are deliberately excluded: NXRM's own server-side validation rejects them
+// with "Firewall does not support repository format '<x>'." - confirmed against a real,
+// connected IQ Server, not merely a schema-level limitation in this provider.
 var firewallProxyTestDataTable = []firewallProxyTestData{
-	{RepoFormat: common.REPO_FORMAT_ALPINE, RemoteUrl: TEST_DATA_ALPINE_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultAlpine},
 	{RepoFormat: common.REPO_FORMAT_CARGO, RemoteUrl: TEST_DATA_CARGO_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultCargo},
 	{RepoFormat: common.REPO_FORMAT_COCOAPODS, RemoteUrl: TEST_DATA_COCOAPODS_PROXY_REMOTE_URL},
 	{RepoFormat: common.REPO_FORMAT_COMPOSER, RemoteUrl: TEST_DATA_COMPOSER_PROXY_REMOTE_URL},
@@ -1072,7 +1070,6 @@ var firewallProxyTestDataTable = []firewallProxyTestData{
 	{RepoFormat: common.REPO_FORMAT_MAVEN, RemoteUrl: TEST_DATA_MAVEN_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultMaven},
 	{RepoFormat: common.REPO_FORMAT_NPM, RemoteUrl: TEST_DATA_NPM_PROXY_REMOTE_URL, SupportsPccs: true},
 	{RepoFormat: common.REPO_FORMAT_NUGET, RemoteUrl: TEST_DATA_NUGET_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultNuget},
-	{RepoFormat: common.REPO_FORMAT_PUB, RemoteUrl: testDataPubProxyRemoteUrl},
 	{RepoFormat: common.REPO_FORMAT_PYPI, RemoteUrl: TEST_DATA_PYPI_PROXY_REMOTE_URL, SupportsPccs: true},
 	{RepoFormat: common.REPO_FORMAT_R, RemoteUrl: TEST_DATA_R_PROXY_REMOTE_URL},
 	{RepoFormat: common.REPO_FORMAT_RAW, RemoteUrl: TEST_DATA_RAW_PROXY_REMOTE_URL, FormatSpecificConfig: configBlockProxyDefaultRaw},
@@ -1144,13 +1141,13 @@ func TestAccRepositoryGenericProxyFirewallToggle(t *testing.T) {
 			resourceName := fmt.Sprintf(repoNameFString, resourceType)
 			repoName := strings.ToLower(fmt.Sprintf(proxyNameFString, td.RepoFormat, randomString))
 
-			enabledChecks := []resource.TestCheckFunc{
+			// capability_id is a legacy field from the pre-3.94 Capability-based firewall API -
+			// the inline firewall path (exercised here) always leaves it null, by design (see
+			// internal/provider/repository/format/proxy_inline_firewall_test.go).
+			quarantineChecks := []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_ENABLED, "true"),
 				resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_QUARANTINE, "true"),
-				resource.TestCheckResourceAttrSet(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_CAPABILITY_ID),
-			}
-			if td.SupportsPccs {
-				enabledChecks = append(enabledChecks, resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_PCCS_ENABLED, "true"))
+				resource.TestCheckNoResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_CAPABILITY_ID),
 			}
 
 			steps := []resource.TestStep{
@@ -1162,19 +1159,34 @@ func TestAccRepositoryGenericProxyFirewallToggle(t *testing.T) {
 						resource.TestCheckNoResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL),
 					),
 				},
-				// 2. Firewall enabled with quarantine (+ PCCS for npm/pypi)
+				// 2. Firewall enabled with quarantine
 				{
-					Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(true, true, td.SupportsPccs)),
-					Check:  resource.ComposeAggregateTestCheckFunc(enabledChecks...),
-				},
-				// 3. Back to no firewall configuration - the #469/#412 regression scenario
-				{
-					Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(false, false, false)),
-					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckNoResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL),
-					),
+					Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(true, true, false)),
+					Check:  resource.ComposeAggregateTestCheckFunc(quarantineChecks...),
 				},
 			}
+
+			// PCCS is its own FirewallMode (common.FirewallModePccs), mutually exclusive with
+			// Quarantine - not a modifier on top of it - so npm/pypi get a dedicated step rather
+			// than combining pccs_enabled=true with quarantine=true above.
+			if td.SupportsPccs {
+				steps = append(steps, resource.TestStep{
+					Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(true, false, true)),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_ENABLED, "true"),
+						resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_QUARANTINE, "false"),
+						resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_PCCS_ENABLED, "true"),
+					),
+				})
+			}
+
+			// 3. Back to no firewall configuration - the #469/#412 regression scenario
+			steps = append(steps, resource.TestStep{
+				Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(false, false, false)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL),
+				),
+			})
 
 			// Import verification for the two formats named in the original bugs' PCCS-capable
 			// class (npm, pypi) - the two formats where this coverage matters most.

--- a/internal/provider/repository/repotest/constants.go
+++ b/internal/provider/repository/repotest/constants.go
@@ -61,6 +61,8 @@ const (
 	RES_ATTR_ROUTING_RULE_NAME                                string = "routing_rule"
 	RES_ATTR_REPOSITORY_FIREWALL_ENABLED                      string = "repository_firewall.enabled"
 	RES_ATTR_REPOSITORY_FIREWALL_QUARANTINE                   string = "repository_firewall.quarantine"
+	RES_ATTR_REPOSITORY_FIREWALL_CAPABILITY_ID                string = "repository_firewall.capability_id"
+	RES_ATTR_REPOSITORY_FIREWALL_PCCS_ENABLED                 string = "repository_firewall.pccs_enabled"
 	RES_ATTR_APT_DISTRIBUTION                                 string = "apt.distribution"
 	RES_ATTR_CARGO_REQUIRE_AUTHENTICATION                     string = "cargo.require_authentication"
 	RES_ATTR_CONAN_PROXY_CONAN_VERSION                        string = "conan.conan_version"

--- a/internal/provider/system/config_iq_connection_resource_test.go
+++ b/internal/provider/system/config_iq_connection_resource_test.go
@@ -17,10 +17,13 @@ package system_test
 
 import (
 	"fmt"
+	"os"
+	"terraform-provider-sonatyperepo/internal/provider/testutil"
 	utils_test "terraform-provider-sonatyperepo/internal/provider/utils"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 const (
@@ -30,91 +33,142 @@ const (
 )
 
 func TestAccSystemIqConnectionResource(t *testing.T) {
+	// resource.Test always destroys resources declared in the final step's config once the test
+	// completes - for this singleton resource, Delete calls DisableIq, which would otherwise
+	// leave Sonatype IQ Server disconnected for any repository_firewall acceptance test running
+	// concurrently in another package. Restore a working connection immediately afterward.
+	if os.Getenv("TF_ACC_IQ_SERVER") == "1" {
+		t.Cleanup(func() {
+			if err := testutil.ConfigureIqConnection(); err != nil {
+				t.Logf("Failed to restore Sonatype IQ Server connection after test: %v", err)
+			}
+		})
+	}
+
+	steps := []resource.TestStep{
+		// Create and Read testing
+		{
+			Config: systemIqConnectionResourceConfig(false),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				// Verify
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "fail_open_mode_enabled", "false"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "nexus_trust_store_enabled", "false"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "url", defaultIqServerUrl),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "username", "user"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "password", "token"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "show_iq_server_link", "false"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "properties", ""),
+				resource.TestCheckResourceAttrSet(resourceNameSysIqConnection, "last_updated"),
+			),
+		},
+		// Test enabling show_iq_server_link
+		{
+			Config: systemIqConnectionResourceConfig(true),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				// Verify
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "fail_open_mode_enabled", "false"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "nexus_trust_store_enabled", "false"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "url", defaultIqServerUrl),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "username", "user"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "password", "token"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "show_iq_server_link", "true"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "properties", ""),
+				resource.TestCheckResourceAttrSet(resourceNameSysIqConnection, "last_updated"),
+			),
+		},
+		// Test adding Properties
+		{
+			Config: systemIqConnectionWithPropertiesResourceConfig(true),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				// Verify
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "fail_open_mode_enabled", "false"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "nexus_trust_store_enabled", "false"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "url", defaultIqServerUrl),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "username", "user"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "password", "token"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "show_iq_server_link", "true"),
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "properties", "key1=value1&key2=value2"),
+				resource.TestCheckResourceAttrSet(resourceNameSysIqConnection, "last_updated"),
+			),
+		},
+		// Test that nexus_trust_store_enabled is applied
+		{
+			Config: systemIqConnectionWithTrustStoreConfig(true),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection,
+					"nexus_trust_store_enabled", "true"),
+			),
+		},
+		// Verify it can be set back to false
+		{
+			Config: systemIqConnectionWithTrustStoreConfig(false),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr(resourceNameSysIqConnection,
+					"nexus_trust_store_enabled", "false"),
+			),
+		},
+		// ImportState testing
+		{
+			ResourceName:                         resourceNameSysIqConnection,
+			ImportState:                          true,
+			ImportStateVerify:                    true,
+			ImportStateVerifyIdentifierAttribute: "url",
+			ImportStateVerifyIgnore: []string{
+				"password",
+				"last_updated",
+			},
+			ImportStateId: "system-iq-config",
+		},
+		// Delete testing automatically occurs in TestCase
+	}
+
+	// Against a real, licensed Sonatype IQ Server (TF_ACC_IQ_SERVER=1), confirm the connection
+	// NXRM ends up with actually works - the steps above only ever exercise fake credentials
+	// against an unreachable URL, which NXRM accepts without validating at write time.
+	if os.Getenv("TF_ACC_IQ_SERVER") == "1" {
+		steps = append(steps, resource.TestStep{
+			Config: systemIqConnectionRealResourceConfig(),
+			Check: func(_ *terraform.State) error {
+				success, reason, err := testutil.VerifyIqConnection()
+				if err != nil {
+					return fmt.Errorf("error verifying Sonatype IQ Server connection: %w", err)
+				}
+				if !success {
+					return fmt.Errorf("Sonatype IQ Server connection was not successful: %s", reason)
+				}
+				return nil
+			},
+		})
+	}
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create and Read testing
-			{
-				Config: systemIqConnectionResourceConfig(false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Verify
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "fail_open_mode_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "nexus_trust_store_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "url", defaultIqServerUrl),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "username", "user"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "password", "token"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "show_iq_server_link", "false"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "properties", ""),
-					resource.TestCheckResourceAttrSet(resourceNameSysIqConnection, "last_updated"),
-				),
-			},
-			// Test enabling show_iq_server_link
-			{
-				Config: systemIqConnectionResourceConfig(true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Verify
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "fail_open_mode_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "nexus_trust_store_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "url", defaultIqServerUrl),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "username", "user"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "password", "token"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "show_iq_server_link", "true"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "properties", ""),
-					resource.TestCheckResourceAttrSet(resourceNameSysIqConnection, "last_updated"),
-				),
-			},
-			// Test adding Properties
-			{
-				Config: systemIqConnectionWithPropertiesResourceConfig(true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Verify
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "fail_open_mode_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "nexus_trust_store_enabled", "false"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "url", defaultIqServerUrl),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "username", "user"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "password", "token"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "show_iq_server_link", "true"),
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection, "properties", "key1=value1&key2=value2"),
-					resource.TestCheckResourceAttrSet(resourceNameSysIqConnection, "last_updated"),
-				),
-			},
-			// Test that nexus_trust_store_enabled is applied
-			{
-				Config: systemIqConnectionWithTrustStoreConfig(true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection,
-						"nexus_trust_store_enabled", "true"),
-				),
-			},
-			// Verify it can be set back to false
-			{
-				Config: systemIqConnectionWithTrustStoreConfig(false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceNameSysIqConnection,
-						"nexus_trust_store_enabled", "false"),
-				),
-			},
-			// ImportState testing
-			{
-				ResourceName:                         resourceNameSysIqConnection,
-				ImportState:                          true,
-				ImportStateVerify:                    true,
-				ImportStateVerifyIdentifierAttribute: "url",
-				ImportStateVerifyIgnore: []string{
-					"password",
-					"last_updated",
-				},
-				ImportStateId: "system-iq-config",
-			},
-			// Delete testing automatically occurs in TestCase
-		},
+		Steps:                    steps,
 	})
+}
+
+// systemIqConnectionRealResourceConfig points sonatyperepo_system_iq_connection at the real IQ
+// Server under test (testutil.IqServerUrl/Username/Password), unlike the fake-credential
+// configs below which only ever exercise attribute CRUD against NXRM's unvalidated write path.
+func systemIqConnectionRealResourceConfig() string {
+	return fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "iq" {
+  authentication_method = "USER"
+  enabled = true
+  fail_open_mode_enabled = false
+  nexus_trust_store_enabled = false
+  url = "%s"
+  username = "%s"
+  password = "%s"
+  show_iq_server_link = true
+}
+`, resourceTypeSysIqConnection, testutil.IqServerUrl(), testutil.IqServerUsername(), testutil.IqServerPassword())
 }
 
 func systemIqConnectionResourceConfig(showIqLink bool) string {

--- a/internal/provider/system/config_iq_connection_resource_test.go
+++ b/internal/provider/system/config_iq_connection_resource_test.go
@@ -33,6 +33,20 @@ const (
 	resourceNameSysIqConnection = "sonatyperepo_system_iq_connection.iq"
 )
 
+// settleIqConnectionWrite pauses briefly before returning, for use as the first entry in a
+// step's Check chain (which - see testing_new_config.go in terraform-plugin-testing - runs
+// immediately after apply and before the framework's own automatic post-apply refresh/empty-plan
+// verification). Observed in CI (twice, on different NXRM versions, ~1 in 28 jobs each time):
+// that automatic refresh occasionally reads back a stale value for a field this test just wrote
+// (e.g. show_iq_server_link), even with no other writer active at the time - consistent with a
+// short-lived read-after-write staleness on NXRM's side for this singleton, not a genuine
+// provider bug or a race with another test. See
+// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
+func settleIqConnectionWrite(_ *terraform.State) error {
+	time.Sleep(3 * time.Second)
+	return nil
+}
+
 func TestAccSystemIqConnectionResource(t *testing.T) {
 	// This test's steps intentionally write conflicting sonatyperepo_system_iq_connection
 	// configuration (fake credentials, toggling show_iq_server_link/nexus_trust_store_enabled),
@@ -64,6 +78,7 @@ func TestAccSystemIqConnectionResource(t *testing.T) {
 		{
 			Config: systemIqConnectionResourceConfig(false),
 			Check: resource.ComposeAggregateTestCheckFunc(
+				settleIqConnectionWrite,
 				// Verify
 				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
 				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
@@ -81,6 +96,7 @@ func TestAccSystemIqConnectionResource(t *testing.T) {
 		{
 			Config: systemIqConnectionResourceConfig(true),
 			Check: resource.ComposeAggregateTestCheckFunc(
+				settleIqConnectionWrite,
 				// Verify
 				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
 				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
@@ -98,6 +114,7 @@ func TestAccSystemIqConnectionResource(t *testing.T) {
 		{
 			Config: systemIqConnectionWithPropertiesResourceConfig(true),
 			Check: resource.ComposeAggregateTestCheckFunc(
+				settleIqConnectionWrite,
 				// Verify
 				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "authentication_method", "USER"),
 				resource.TestCheckResourceAttr(resourceNameSysIqConnection, "enabled", "true"),
@@ -115,6 +132,7 @@ func TestAccSystemIqConnectionResource(t *testing.T) {
 		{
 			Config: systemIqConnectionWithTrustStoreConfig(true),
 			Check: resource.ComposeAggregateTestCheckFunc(
+				settleIqConnectionWrite,
 				resource.TestCheckResourceAttr(resourceNameSysIqConnection,
 					"nexus_trust_store_enabled", "true"),
 			),
@@ -123,6 +141,7 @@ func TestAccSystemIqConnectionResource(t *testing.T) {
 		{
 			Config: systemIqConnectionWithTrustStoreConfig(false),
 			Check: resource.ComposeAggregateTestCheckFunc(
+				settleIqConnectionWrite,
 				resource.TestCheckResourceAttr(resourceNameSysIqConnection,
 					"nexus_trust_store_enabled", "false"),
 			),

--- a/internal/provider/system/config_iq_connection_resource_test.go
+++ b/internal/provider/system/config_iq_connection_resource_test.go
@@ -21,6 +21,7 @@ import (
 	"terraform-provider-sonatyperepo/internal/provider/testutil"
 	utils_test "terraform-provider-sonatyperepo/internal/provider/utils"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -33,11 +34,24 @@ const (
 )
 
 func TestAccSystemIqConnectionResource(t *testing.T) {
-	// resource.Test always destroys resources declared in the final step's config once the test
-	// completes - for this singleton resource, Delete calls DisableIq, which would otherwise
-	// leave Sonatype IQ Server disconnected for any repository_firewall acceptance test running
-	// concurrently in another package. Restore a working connection immediately afterward.
+	// This test's steps intentionally write conflicting sonatyperepo_system_iq_connection
+	// configuration (fake credentials, toggling show_iq_server_link/nexus_trust_store_enabled),
+	// and resource.Test's implicit end-of-test destroy calls DisableIq - all directly against
+	// the same singleton that internal/provider/provider_test.go's TestMain bootstraps at the
+	// start of its own package's test binary. Since `go test ./...` compiles each package to a
+	// separate binary and can run them concurrently, hold a cross-process lock for the entire
+	// test (steps + destroy + restore) so that bootstrap can't interleave with it and produce
+	// spurious refresh drift (observed in CI - see
+	// https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285).
 	if os.Getenv("TF_ACC_IQ_SERVER") == "1" {
+		unlock, err := testutil.LockIqConnection(2 * time.Minute)
+		if err != nil {
+			t.Fatalf("Failed to acquire IQ connection lock: %v", err)
+		}
+		// Cleanups run last-added-first: register the unlock first (so it runs last, releasing
+		// only after the restore below has run), then the restore (so it runs first, while the
+		// lock is still held).
+		t.Cleanup(unlock)
 		t.Cleanup(func() {
 			if err := testutil.ConfigureIqConnection(); err != nil {
 				t.Logf("Failed to restore Sonatype IQ Server connection after test: %v", err)

--- a/internal/provider/testutil/testutils.go
+++ b/internal/provider/testutil/testutils.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"testing"
+	"time"
 
 	semver "github.com/hashicorp/go-version"
 	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
@@ -134,6 +136,47 @@ func VerifyIqConnection() (success bool, reason string, err error) {
 		reason = *verification.Reason
 	}
 	return *verification.Success, reason, nil
+}
+
+// iqConnectionLockPath is a fixed path in the OS temp directory, shared by every package's test
+// binary within a single `go test ./...` invocation (each package compiles to a separate binary
+// and can run concurrently, so an in-process mutex can't coordinate across them).
+func iqConnectionLockPath() string {
+	return filepath.Join(os.TempDir(), "terraform-provider-sonatyperepo-iq-connection.lock")
+}
+
+// iqConnectionLockStaleAfter bounds how long a lock file is honored before it's treated as
+// abandoned (e.g. left behind by a crashed local test run) and removed so a new lock can be
+// acquired. CI runners are ephemeral and never see a stale lock; this only protects local runs.
+const iqConnectionLockStaleAfter = 5 * time.Minute
+
+// LockIqConnection acquires a simple, cross-process file lock guarding writes to the shared
+// sonatyperepo_system_iq_connection singleton, so TestMain's bootstrap
+// (internal/provider/provider_test.go) and TestAccSystemIqConnectionResource
+// (internal/provider/system) - separate `go test` binaries that `go test ./...` can run
+// concurrently - can't interleave their writes to it and produce spurious drift. Blocks
+// (polling) until acquired or timeout elapses; the returned func must be called to release.
+func LockIqConnection(timeout time.Duration) (unlock func(), err error) {
+	path := iqConnectionLockPath()
+	deadline := time.Now().Add(timeout)
+	for {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+		if err == nil {
+			_ = f.Close()
+			return func() { _ = os.Remove(path) }, nil
+		}
+		if !os.IsExist(err) {
+			return nil, err
+		}
+		if info, statErr := os.Stat(path); statErr == nil && time.Since(info.ModTime()) > iqConnectionLockStaleAfter {
+			_ = os.Remove(path)
+			continue
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out after %s waiting for IQ connection lock at %s", timeout, path)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 func SkipIfNxrmVersionEq(t *testing.T, v *common.SystemVersion) {

--- a/internal/provider/testutil/testutils.go
+++ b/internal/provider/testutil/testutils.go
@@ -140,16 +140,19 @@ func VerifyIqConnection() (success bool, reason string, err error) {
 
 // iqConnectionLockPath returns a fixed path shared by every package's test binary within a
 // single `go test ./...` invocation (each package compiles to a separate binary and can run
-// concurrently, so an in-process mutex can't coordinate across them). It lives in a
-// process-owner-scoped, 0700 subdirectory of the OS temp directory rather than directly in it:
-// os.TempDir() itself (e.g. /tmp) is world-writable, and a predictable path directly inside it
-// is flagged (rightly, for the general case) as CWE-377/379 - another local user could plant or
-// pre-create that exact path. Scoping to a per-UID subdirectory this process itself creates with
-// restrictive permissions closes that off, while keeping the path deterministic and shared for
-// every test binary run by the same user in the same `go test ./...` invocation, which the lock
-// depends on.
+// concurrently, so an in-process mutex can't coordinate across them). It deliberately avoids
+// os.TempDir() (e.g. /tmp): that directory is world-writable, and SonarQube rightly flags any
+// predictable path built from it as CWE-377/379 - another local user could plant or pre-create
+// that exact path. os.UserCacheDir() is per-user by definition (~/.cache, ~/Library/Caches,
+// %LocalAppData%, ...), so a subdirectory under it stays deterministic and shared for every test
+// binary run by the same user - which the lock depends on - without that exposure. The 0700
+// subdirectory this process creates is still applied on top as a second layer of defense.
 func iqConnectionLockPath() (string, error) {
-	dir := filepath.Join(os.TempDir(), fmt.Sprintf("terraform-provider-sonatyperepo-%d", os.Getuid()))
+	base, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve user cache directory: %w", err)
+	}
+	dir := filepath.Join(base, "terraform-provider-sonatyperepo")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}

--- a/internal/provider/testutil/testutils.go
+++ b/internal/provider/testutil/testutils.go
@@ -138,11 +138,22 @@ func VerifyIqConnection() (success bool, reason string, err error) {
 	return *verification.Success, reason, nil
 }
 
-// iqConnectionLockPath is a fixed path in the OS temp directory, shared by every package's test
-// binary within a single `go test ./...` invocation (each package compiles to a separate binary
-// and can run concurrently, so an in-process mutex can't coordinate across them).
-func iqConnectionLockPath() string {
-	return filepath.Join(os.TempDir(), "terraform-provider-sonatyperepo-iq-connection.lock")
+// iqConnectionLockPath returns a fixed path shared by every package's test binary within a
+// single `go test ./...` invocation (each package compiles to a separate binary and can run
+// concurrently, so an in-process mutex can't coordinate across them). It lives in a
+// process-owner-scoped, 0700 subdirectory of the OS temp directory rather than directly in it:
+// os.TempDir() itself (e.g. /tmp) is world-writable, and a predictable path directly inside it
+// is flagged (rightly, for the general case) as CWE-377/379 - another local user could plant or
+// pre-create that exact path. Scoping to a per-UID subdirectory this process itself creates with
+// restrictive permissions closes that off, while keeping the path deterministic and shared for
+// every test binary run by the same user in the same `go test ./...` invocation, which the lock
+// depends on.
+func iqConnectionLockPath() (string, error) {
+	dir := filepath.Join(os.TempDir(), fmt.Sprintf("terraform-provider-sonatyperepo-%d", os.Getuid()))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "iq-connection.lock"), nil
 }
 
 // iqConnectionLockStaleAfter bounds how long a lock file is honored before it's treated as
@@ -157,7 +168,10 @@ const iqConnectionLockStaleAfter = 5 * time.Minute
 // concurrently - can't interleave their writes to it and produce spurious drift. Blocks
 // (polling) until acquired or timeout elapses; the returned func must be called to release.
 func LockIqConnection(timeout time.Duration) (unlock func(), err error) {
-	path := iqConnectionLockPath()
+	path, err := iqConnectionLockPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare IQ connection lock directory: %w", err)
+	}
 	deadline := time.Now().Add(timeout)
 	for {
 		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)

--- a/internal/provider/testutil/testutils.go
+++ b/internal/provider/testutil/testutils.go
@@ -17,15 +17,124 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"strings"
 	"terraform-provider-sonatyperepo/internal/provider/common"
 	"testing"
 
 	semver "github.com/hashicorp/go-version"
+	v3 "github.com/sonatype-nexus-community/nexus-repo-api-client-go/v3"
 )
 
 var CurrenTestNxrmVersion = common.ParseServerHeaderToVersion(fmt.Sprintf("Nexus/%s (PRO)", os.Getenv("NXRM_VERSION")))
+
+// SkipIfNoIqServer skips a test unless TF_ACC_IQ_SERVER=1 is set. This mirrors the
+// TF_ACC_S3_BLOB_STORE / TF_ACC_GCS_BLOB_STORE opt-in pattern (see
+// internal/provider/blob_store/blob_store_s3_resource_test.go) for tests that need a real,
+// licensed Sonatype IQ Server connected to the NXRM instance under test - infrastructure that
+// isn't present by default, so a plain local `TF_ACC=1 go test ./...` run skips these instead
+// of failing. See https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/issues/285.
+func SkipIfNoIqServer(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("TF_ACC_IQ_SERVER") != "1" {
+		t.Skip("Sonatype IQ Server tests require a live IQ Server connected to Sonatype Nexus Repository Manager - set TF_ACC_IQ_SERVER=1 to enable")
+	}
+}
+
+// IqServerUrl returns the URL of the Sonatype IQ Server under test, defaulting to the
+// well-known local port used by both this provider's CI workflows and the sibling
+// terraform-provider-sonatypeiq project.
+func IqServerUrl() string {
+	if v := os.Getenv("IQ_SERVER_URL"); v != "" {
+		return v
+	}
+	return "http://localhost:8070"
+}
+
+// IqServerUsername returns the username to authenticate NXRM's connection to IQ Server with.
+func IqServerUsername() string {
+	if v := os.Getenv("IQ_SERVER_USERNAME"); v != "" {
+		return v
+	}
+	return "admin"
+}
+
+// IqServerPassword returns the password to authenticate NXRM's connection to IQ Server with.
+func IqServerPassword() string {
+	if v := os.Getenv("IQ_SERVER_PASSWORD"); v != "" {
+		return v
+	}
+	return "admin123"
+}
+
+// nxrmV3Client builds a raw NXRM API client from NXRM_SERVER_URL/USERNAME/PASSWORD, bypassing
+// the provider entirely - used for imperative test setup, mirroring the pattern already used in
+// internal/provider/provider_test.go's TestMain for HA fixture bootstrapping.
+func nxrmV3Client() (*v3.APIClient, context.Context) {
+	clientConfiguration := v3.NewConfiguration()
+	clientConfiguration.Servers = []v3.ServerConfiguration{
+		{
+			URL:         fmt.Sprintf("%s%s", strings.TrimRight(os.Getenv("NXRM_SERVER_URL"), "/"), "/service/rest"),
+			Description: "Sonatype Nexus Repository Server",
+		},
+	}
+	client := v3.NewAPIClient(clientConfiguration)
+	ctx := context.WithValue(
+		context.Background(),
+		v3.ContextBasicAuth,
+		v3.BasicAuth{UserName: os.Getenv("NXRM_SERVER_USERNAME"), Password: os.Getenv("NXRM_SERVER_PASSWORD")},
+	)
+	return client, ctx
+}
+
+// ConfigureIqConnection points the NXRM instance under test (NXRM_SERVER_URL) at the Sonatype IQ
+// Server described by IqServerUrl/IqServerUsername/IqServerPassword. Used both to bootstrap the
+// connection once before any acceptance test runs (TestMain, gated on TF_ACC_IQ_SERVER=1) and to
+// restore it after tests that intentionally disable it (e.g. TestAccSystemIqConnectionResource's
+// implicit end-of-test destroy), so a disable in one package can't leave it down for others
+// running concurrently.
+func ConfigureIqConnection() error {
+	client, ctx := nxrmV3Client()
+
+	_, httpResponse, err := client.ManageSonatypeRepositoryFirewallConfigurationAPI.UpdateConfiguration1(ctx).Body(v3.IqConnectionXo{
+		AuthenticationType:  "USER",
+		Enabled:             v3.PtrBool(true),
+		FailOpenModeEnabled: v3.PtrBool(false),
+		ShowLink:            v3.PtrBool(true),
+		Url:                 v3.PtrString(IqServerUrl()),
+		Username:            v3.PtrString(IqServerUsername()),
+		Password:            v3.PtrString(IqServerPassword()),
+	}).Execute()
+	if err != nil {
+		return err
+	}
+	if httpResponse != nil && httpResponse.StatusCode != http.StatusNoContent && httpResponse.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected response configuring Sonatype IQ Server connection: %s", httpResponse.Status)
+	}
+	return nil
+}
+
+// VerifyIqConnection asks NXRM to verify its currently configured Sonatype IQ Server connection,
+// returning whether it succeeded and, on failure, the reason NXRM gave.
+func VerifyIqConnection() (success bool, reason string, err error) {
+	client, ctx := nxrmV3Client()
+
+	verification, _, err := client.ManageSonatypeRepositoryFirewallConfigurationAPI.VerifyIqConnection(ctx).Execute()
+	if err != nil {
+		return false, "", err
+	}
+	if verification == nil || verification.Success == nil {
+		return false, "", nil
+	}
+	if verification.Reason != nil {
+		reason = *verification.Reason
+	}
+	return *verification.Success, reason, nil
+}
 
 func SkipIfNxrmVersionEq(t *testing.T, v *common.SystemVersion) {
 	t.Helper()


### PR DESCRIPTION
Boots a single pinned IQ Server instance in both trusted CI workflows and bootstraps/verifies the NXRM->IQ connection via a Go TestMain hook before acceptance tests run, so `repository_firewall` can finally be exercised against a real, connected IQ Server instead of failing with "not connected to Sonatype IQ". Adds live enable/disable coverage for all 17 inline-firewall proxy formats (the exact #469/#412 regression shape) and a real-connection check for `sonatyperepo_system_iq_connection`.

New tests are gated behind `TF_ACC_IQ_SERVER=1` so a plain local `TF_ACC=1` run against NXRM alone still passes. `CONTRIBUTING.md` documents the new flag and env vars, and fixes a pre-existing inaccuracy that claimed base acceptance tests required IQ Server.

Closes #285.