### PR TITLE
fix: Prevent inconsistent apply result for repository_firewall.enabled = false (GH-469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## UNRELEASED
 
-*tbc*
+BUG FIXES:
+* Prevent `Provider produced inconsistent result after apply` error when `repository_firewall.enabled = false` is explicitly configured against Sonatype Nexus Repository 3.94.0+ [GH-469] - this affected every proxy repository format supporting `repository_firewall`, not just NPM as originally reported: `sonatyperepo_repository_alpine_proxy`, `sonatyperepo_repository_cargo_proxy`, `sonatyperepo_repository_cocoapods_proxy`, `sonatyperepo_repository_composer_proxy`, `sonatyperepo_repository_conan_proxy`, `sonatyperepo_repository_conda_proxy`, `sonatyperepo_repository_docker_proxy`, `sonatyperepo_repository_go_proxy`, `sonatyperepo_repository_huggingface_proxy`, `sonatyperepo_repository_maven2_proxy`, `sonatyperepo_repository_npm_proxy`, `sonatyperepo_repository_nuget_proxy`, `sonatyperepo_repository_pub_proxy`, `sonatyperepo_repository_pypi_proxy`, `sonatyperepo_repository_r_proxy`, `sonatyperepo_repository_raw_proxy`, `sonatyperepo_repository_rubygems_proxy` and `sonatyperepo_repository_yum_proxy` resources
 
 ## 1.17.0 Aug 25, 2026
 

--- a/internal/provider/repository/format/alpine.go
+++ b/internal/provider/repository/format/alpine.go
@@ -260,7 +260,7 @@ func (f *AlpineRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, s
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/alpine.go
+++ b/internal/provider/repository/format/alpine.go
@@ -232,13 +232,13 @@ func (f *AlpineRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.AlpineProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -260,6 +260,7 @@ func (f *AlpineRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, s
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/cargo.go
+++ b/internal/provider/repository/format/cargo.go
@@ -218,13 +218,13 @@ func (f *CargoRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.CargoProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -246,6 +246,7 @@ func (f *CargoRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/cargo.go
+++ b/internal/provider/repository/format/cargo.go
@@ -246,7 +246,7 @@ func (f *CargoRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/cocoapods.go
+++ b/internal/provider/repository/format/cocoapods.go
@@ -132,13 +132,13 @@ func (f *CocoaPodsRepositoryFormatProxy) UpdateStateFromApi(state any, api any) 
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -160,6 +160,7 @@ func (f *CocoaPodsRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/cocoapods.go
+++ b/internal/provider/repository/format/cocoapods.go
@@ -160,7 +160,7 @@ func (f *CocoaPodsRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/composer.go
+++ b/internal/provider/repository/format/composer.go
@@ -160,7 +160,7 @@ func (f *ComposerRepositoryFormat) UpdateStateFromPlanForNonApiFields(plan, stat
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/composer.go
+++ b/internal/provider/repository/format/composer.go
@@ -132,13 +132,13 @@ func (f *ComposerRepositoryFormat) UpdateStateFromApi(state any, api any) any {
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -160,6 +160,7 @@ func (f *ComposerRepositoryFormat) UpdateStateFromPlanForNonApiFields(plan, stat
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/conan.go
+++ b/internal/provider/repository/format/conan.go
@@ -249,7 +249,7 @@ func (f *ConanRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/conan.go
+++ b/internal/provider/repository/format/conan.go
@@ -221,13 +221,13 @@ func (f *ConanRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.ConanProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -249,6 +249,7 @@ func (f *ConanRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/conda.go
+++ b/internal/provider/repository/format/conda.go
@@ -132,13 +132,13 @@ func (f *CondaRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -160,6 +160,7 @@ func (f *CondaRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/conda.go
+++ b/internal/provider/repository/format/conda.go
@@ -160,7 +160,7 @@ func (f *CondaRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/docker.go
+++ b/internal/provider/repository/format/docker.go
@@ -274,7 +274,7 @@ func (f *DockerRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, s
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/docker.go
+++ b/internal/provider/repository/format/docker.go
@@ -246,13 +246,13 @@ func (f *DockerRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.DockerProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -274,6 +274,7 @@ func (f *DockerRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, s
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/go.go
+++ b/internal/provider/repository/format/go.go
@@ -140,13 +140,13 @@ func (f *GoRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -168,6 +168,7 @@ func (f *GoRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, state
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/go.go
+++ b/internal/provider/repository/format/go.go
@@ -168,7 +168,7 @@ func (f *GoRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, state
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/huggingface.go
+++ b/internal/provider/repository/format/huggingface.go
@@ -160,7 +160,7 @@ func (f *HuggingFaceRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(pl
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/huggingface.go
+++ b/internal/provider/repository/format/huggingface.go
@@ -132,13 +132,13 @@ func (f *HuggingFaceRepositoryFormatProxy) UpdateStateFromApi(state any, api any
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -160,6 +160,7 @@ func (f *HuggingFaceRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(pl
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/maven.go
+++ b/internal/provider/repository/format/maven.go
@@ -221,13 +221,13 @@ func (f *MavenRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.MavenProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -249,6 +249,7 @@ func (f *MavenRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/maven.go
+++ b/internal/provider/repository/format/maven.go
@@ -249,7 +249,7 @@ func (f *MavenRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/npm.go
+++ b/internal/provider/repository/format/npm.go
@@ -218,13 +218,13 @@ func (f *NpmRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.NpmProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, pccsEnabled := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineWithPccsModelWithDefaults()
 				}
-				enabled, quarantine, pccsEnabled := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -247,6 +247,7 @@ func (f *NpmRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, stat
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockWithPccsFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/npm.go
+++ b/internal/provider/repository/format/npm.go
@@ -247,7 +247,7 @@ func (f *NpmRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, stat
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockWithPccsFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPccsPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/nuget.go
+++ b/internal/provider/repository/format/nuget.go
@@ -220,13 +220,13 @@ func (f *NugetRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any 
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.NugetProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -248,6 +248,7 @@ func (f *NugetRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/nuget.go
+++ b/internal/provider/repository/format/nuget.go
@@ -248,7 +248,7 @@ func (f *NugetRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, st
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/proxy.go
+++ b/internal/provider/repository/format/proxy.go
@@ -99,15 +99,35 @@ func ResolveFirewallBlockFlags(hadConfig bool, mode common.FirewallMode) (keep, 
 	return keep, enabled, quarantine, pccsEnabled
 }
 
-// BackfillFirewallBlockFromPlan mirrors planFirewall into state (creating the block if
-// necessary, with capability_id cleared) when the plan configured `repository_firewall` but
-// stateFirewall is still nil. This covers the one case ResolveFirewallBlockFlags can't see on
-// its own: Update() feeds UpdateStateFromApi the PRIOR state rather than the new plan (see
-// repository_common.go), so adding the block for the first time with `enabled = false` in the
-// same apply isn't visible there. UpdateStateFromPlanForNonApiFields has both the plan and the
-// post-read state, so it's the right place to catch this up. See GH-469.
-func BackfillFirewallBlockFromPlan(stateFirewall, planFirewall *model.FirewallAuditAndQuarantineModel) *model.FirewallAuditAndQuarantineModel {
-	if stateFirewall != nil || planFirewall == nil {
+// ReconcileFirewallBlockWithPlan makes `repository_firewall` in state match whether the NEW
+// plan configured it, overriding whatever ResolveFirewallBlockFlags decided inside
+// UpdateStateFromApi using the PRIOR state - the only signal available to it in the Update()
+// path (see repository_common.go, which feeds UpdateStateFromApi the prior state rather than
+// the new plan). This must be reconciled in both directions:
+//
+//   - The plan has no block, but state still carries one over from before the apply: force
+//     nil. Without this, disabling the firewall by removing the `repository_firewall` block
+//     entirely (rather than setting `enabled = false`) leaves a stale non-null block in state
+//     after an Update() that turns it off, because ResolveFirewallBlockFlags saw the prior
+//     state's now-stale block and concluded it was still configured. Terraform's plan (built
+//     from the new, block-less config) is null, so the stale non-null state fails the same
+//     "Provider produced inconsistent result after apply" check GH-469 was about - just from
+//     the opposite direction.
+//   - The plan has a block, but state is nil: backfill from the plan. This is the
+//     first-time-add-with-`enabled = false"` transition GH-469 was actually filed for -
+//     UpdateStateFromApi can't see it because Update() only hands it the prior (block-less)
+//     state, not the new plan.
+//
+// When state already has a non-nil block that the plan also wants, its values - resolved from
+// the live server mode via FirewallFlagsFromMode, not copied from the plan - are left
+// untouched: they're more trustworthy for flag combinations the server itself resolves
+// differently than configured (e.g. `quarantine = true` together with `pccs_enabled = true`,
+// which NXRM silently resolves to PCCS mode with quarantine reported back as false).
+func ReconcileFirewallBlockWithPlan(stateFirewall, planFirewall *model.FirewallAuditAndQuarantineModel) *model.FirewallAuditAndQuarantineModel {
+	if planFirewall == nil {
+		return nil
+	}
+	if stateFirewall != nil {
 		return stateFirewall
 	}
 	backfilled := *planFirewall
@@ -115,10 +135,13 @@ func BackfillFirewallBlockFromPlan(stateFirewall, planFirewall *model.FirewallAu
 	return &backfilled
 }
 
-// BackfillFirewallBlockWithPccsFromPlan is BackfillFirewallBlockFromPlan for the PCCS-capable
+// ReconcileFirewallBlockWithPccsPlan is ReconcileFirewallBlockWithPlan for the PCCS-capable
 // variant of the `repository_firewall` block (NPM, PyPI). See GH-469.
-func BackfillFirewallBlockWithPccsFromPlan(stateFirewall, planFirewall *model.FirewallAuditAndQuarantineWithPccsModel) *model.FirewallAuditAndQuarantineWithPccsModel {
-	if stateFirewall != nil || planFirewall == nil {
+func ReconcileFirewallBlockWithPccsPlan(stateFirewall, planFirewall *model.FirewallAuditAndQuarantineWithPccsModel) *model.FirewallAuditAndQuarantineWithPccsModel {
+	if planFirewall == nil {
+		return nil
+	}
+	if stateFirewall != nil {
 		return stateFirewall
 	}
 	backfilled := *planFirewall

--- a/internal/provider/repository/format/proxy.go
+++ b/internal/provider/repository/format/proxy.go
@@ -19,6 +19,7 @@ package format
 import (
 	"regexp"
 	"terraform-provider-sonatyperepo/internal/provider/common"
+	"terraform-provider-sonatyperepo/internal/provider/model"
 	"terraform-provider-sonatyperepo/internal/provider/validators"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
@@ -77,6 +78,52 @@ func ComputeFirewallMode(f RepositoryFormat, state any) common.FirewallMode {
 		pccsEnabled = f.GetRepositoryFirewallPccsEnabled(state)
 	}
 	return FirewallModeFromFlags(hasConfig, enabled, quarantine, pccsEnabled)
+}
+
+// ResolveFirewallBlockFlags reconciles the `repository_firewall` state attribute against the
+// inline `firewall.mode` (NXRM 3.94+) reported by DoReadRequest/DoImportRequest, given
+// whether the incoming state/plan model already had a `repository_firewall` block
+// configured.
+//
+// `repository_firewall` is Optional but not Computed, with no plan modifier (see
+// commonProxyFirewallAuditQuarantineAttribute), so Terraform always builds its planned value
+// directly from the practitioner's config. If the block was configured - even with
+// `enabled = false` - the plan is a non-null object; unconditionally nulling the whole
+// attribute out just because the server resolves the mode as disabled then makes apply fail
+// with "Provider produced inconsistent result after apply" (see GH-469). A resolved Disabled
+// mode should only clear the block when it was never configured to begin with - otherwise
+// it's just another set of flags to report, the same as Audit/Quarantine/Pccs.
+func ResolveFirewallBlockFlags(hadConfig bool, mode common.FirewallMode) (keep, enabled, quarantine, pccsEnabled bool) {
+	enabled, quarantine, pccsEnabled = FirewallFlagsFromMode(mode)
+	keep = hadConfig || mode != common.FirewallModeDisabled
+	return keep, enabled, quarantine, pccsEnabled
+}
+
+// BackfillFirewallBlockFromPlan mirrors planFirewall into state (creating the block if
+// necessary, with capability_id cleared) when the plan configured `repository_firewall` but
+// stateFirewall is still nil. This covers the one case ResolveFirewallBlockFlags can't see on
+// its own: Update() feeds UpdateStateFromApi the PRIOR state rather than the new plan (see
+// repository_common.go), so adding the block for the first time with `enabled = false` in the
+// same apply isn't visible there. UpdateStateFromPlanForNonApiFields has both the plan and the
+// post-read state, so it's the right place to catch this up. See GH-469.
+func BackfillFirewallBlockFromPlan(stateFirewall, planFirewall *model.FirewallAuditAndQuarantineModel) *model.FirewallAuditAndQuarantineModel {
+	if stateFirewall != nil || planFirewall == nil {
+		return stateFirewall
+	}
+	backfilled := *planFirewall
+	backfilled.CapabilityId = types.StringNull()
+	return &backfilled
+}
+
+// BackfillFirewallBlockWithPccsFromPlan is BackfillFirewallBlockFromPlan for the PCCS-capable
+// variant of the `repository_firewall` block (NPM, PyPI). See GH-469.
+func BackfillFirewallBlockWithPccsFromPlan(stateFirewall, planFirewall *model.FirewallAuditAndQuarantineWithPccsModel) *model.FirewallAuditAndQuarantineWithPccsModel {
+	if stateFirewall != nil || planFirewall == nil {
+		return stateFirewall
+	}
+	backfilled := *planFirewall
+	backfilled.CapabilityId = types.StringNull()
+	return &backfilled
 }
 
 // ProxyApiResponseWithFirewall carries a proxy repository API response together with its

--- a/internal/provider/repository/format/proxy_inline_firewall_test.go
+++ b/internal/provider/repository/format/proxy_inline_firewall_test.go
@@ -304,13 +304,20 @@ func TestResolveFirewallBlockFlags(t *testing.T) {
 	}
 }
 
-// TestBackfillFirewallBlockFromPlan covers the second half of the GH-469 fix: Update() feeds
-// UpdateStateFromApi the PRIOR state rather than the new plan (see repository_common.go), so
-// adding repository_firewall for the first time with enabled = false in the same apply isn't
-// visible to ResolveFirewallBlockFlags there - state ends up nil even though the plan expects
-// an object. UpdateStateFromPlanForNonApiFields (which has both the plan and the post-read
-// state) must catch this up.
-func TestBackfillFirewallBlockFromPlan(t *testing.T) {
+// TestReconcileFirewallBlockWithPlan covers the second half of the GH-469 fix in both
+// directions. Update() feeds UpdateStateFromApi the PRIOR state rather than the new plan (see
+// repository_common.go), so ResolveFirewallBlockFlags there can be wrong in either direction
+// once the real plan is known:
+//   - adding repository_firewall for the first time with enabled = false in the same apply
+//     isn't visible there - state ends up nil even though the plan expects an object.
+//   - removing repository_firewall entirely (rather than setting enabled = false) leaves
+//     ResolveFirewallBlockFlags looking at the prior state's now-stale non-nil block and
+//     concluding it's still configured - state ends up non-nil even though the plan expects
+//     null.
+//
+// UpdateStateFromPlanForNonApiFields (which has both the plan and the post-read state) is
+// what catches both of these up.
+func TestReconcileFirewallBlockWithPlan(t *testing.T) {
 	t.Run("backfills from plan when state is nil but plan configured the block", func(t *testing.T) {
 		planFirewall := &model.FirewallAuditAndQuarantineModel{
 			CapabilityId: types.StringValue("should-be-cleared"),
@@ -318,7 +325,7 @@ func TestBackfillFirewallBlockFromPlan(t *testing.T) {
 			Quarantine:   types.BoolValue(false),
 		}
 
-		result := BackfillFirewallBlockFromPlan(nil, planFirewall)
+		result := ReconcileFirewallBlockWithPlan(nil, planFirewall)
 
 		if assert.NotNil(t, result) {
 			assert.False(t, result.Enabled.ValueBool())
@@ -328,22 +335,30 @@ func TestBackfillFirewallBlockFromPlan(t *testing.T) {
 	})
 
 	t.Run("leaves state nil when plan never configured the block either", func(t *testing.T) {
-		assert.Nil(t, BackfillFirewallBlockFromPlan(nil, nil))
+		assert.Nil(t, ReconcileFirewallBlockWithPlan(nil, nil))
 	})
 
-	t.Run("never overwrites a non-nil state value", func(t *testing.T) {
+	t.Run("never overwrites a non-nil state value the plan still wants", func(t *testing.T) {
 		stateFirewall := &model.FirewallAuditAndQuarantineModel{Enabled: types.BoolValue(true)}
 		planFirewall := &model.FirewallAuditAndQuarantineModel{Enabled: types.BoolValue(false)}
 
-		result := BackfillFirewallBlockFromPlan(stateFirewall, planFirewall)
+		result := ReconcileFirewallBlockWithPlan(stateFirewall, planFirewall)
 
 		assert.Same(t, stateFirewall, result)
 	})
+
+	t.Run("clears a stale non-nil state value when the plan removed the block", func(t *testing.T) {
+		stateFirewall := &model.FirewallAuditAndQuarantineModel{Enabled: types.BoolValue(true)}
+
+		result := ReconcileFirewallBlockWithPlan(stateFirewall, nil)
+
+		assert.Nil(t, result)
+	})
 }
 
-// TestBackfillFirewallBlockWithPccsFromPlan mirrors TestBackfillFirewallBlockFromPlan for the
+// TestReconcileFirewallBlockWithPccsPlan mirrors TestReconcileFirewallBlockWithPlan for the
 // PCCS-capable variant of the block (NPM, PyPI).
-func TestBackfillFirewallBlockWithPccsFromPlan(t *testing.T) {
+func TestReconcileFirewallBlockWithPccsPlan(t *testing.T) {
 	t.Run("backfills from plan when state is nil but plan configured the block", func(t *testing.T) {
 		planFirewall := &model.FirewallAuditAndQuarantineWithPccsModel{
 			FirewallAuditAndQuarantineModel: model.FirewallAuditAndQuarantineModel{
@@ -354,7 +369,7 @@ func TestBackfillFirewallBlockWithPccsFromPlan(t *testing.T) {
 			PccsEnabled: types.BoolValue(false),
 		}
 
-		result := BackfillFirewallBlockWithPccsFromPlan(nil, planFirewall)
+		result := ReconcileFirewallBlockWithPccsPlan(nil, planFirewall)
 
 		if assert.NotNil(t, result) {
 			assert.False(t, result.Enabled.ValueBool())
@@ -365,7 +380,17 @@ func TestBackfillFirewallBlockWithPccsFromPlan(t *testing.T) {
 	})
 
 	t.Run("leaves state nil when plan never configured the block either", func(t *testing.T) {
-		assert.Nil(t, BackfillFirewallBlockWithPccsFromPlan(nil, nil))
+		assert.Nil(t, ReconcileFirewallBlockWithPccsPlan(nil, nil))
+	})
+
+	t.Run("clears a stale non-nil state value when the plan removed the block", func(t *testing.T) {
+		stateFirewall := &model.FirewallAuditAndQuarantineWithPccsModel{
+			FirewallAuditAndQuarantineModel: model.FirewallAuditAndQuarantineModel{Enabled: types.BoolValue(true)},
+		}
+
+		result := ReconcileFirewallBlockWithPccsPlan(stateFirewall, nil)
+
+		assert.Nil(t, result)
 	})
 }
 
@@ -399,4 +424,36 @@ func TestNpmProxyUpdateStateFromPlanForNonApiFieldsBackfillsNewlyConfiguredFirew
 		assert.False(t, stateModel.FirewallAuditAndQuarantine.PccsEnabled.ValueBool())
 		assert.True(t, stateModel.FirewallAuditAndQuarantine.CapabilityId.IsNull())
 	}
+}
+
+// TestNugetProxyUpdateFlowClearsFirewallWhenBlockRemovedAfterBeingEnabled reproduces, end to
+// end through the exact two calls repository_common.go's Update() makes
+// (UpdateStateFromApi then UpdateStateFromPlanForNonApiFields), the opposite-direction
+// regression this fix's first version introduced: disabling the firewall by removing the
+// `repository_firewall` block entirely (rather than setting enabled = false) after it was
+// previously enabled. Caught by reviewing this fix against
+// TestAccRepositoryGenericProxyFirewallToggle's live step 2 -> step 3 transition before that
+// acceptance test could be run against a real IQ Server.
+func TestNugetProxyUpdateFlowClearsFirewallWhenBlockRemovedAfterBeingEnabled(t *testing.T) {
+	f := &NugetRepositoryFormatProxy{}
+
+	// Prior state: repository_firewall was enabled+quarantine from a previous apply.
+	priorState := model.RepositoryNugetProxyModel{
+		FirewallAuditAndQuarantine: &model.FirewallAuditAndQuarantineModel{
+			Enabled:    types.BoolValue(true),
+			Quarantine: types.BoolValue(true),
+		},
+	}
+	// New plan: block removed entirely (disable by deleting the config block, not enabled = false).
+	planModel := model.RepositoryNugetProxyModel{}
+
+	mode := common.FirewallModeDisabled
+	stateAfterApi := f.UpdateStateFromApi(priorState, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.NugetProxyApiRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryNugetProxyModel)
+
+	finalState := f.UpdateStateFromPlanForNonApiFields(planModel, stateAfterApi).(model.RepositoryNugetProxyModel)
+
+	assert.Nil(t, finalState.FirewallAuditAndQuarantine)
 }

--- a/internal/provider/repository/format/proxy_inline_firewall_test.go
+++ b/internal/provider/repository/format/proxy_inline_firewall_test.go
@@ -80,15 +80,39 @@ func TestMavenProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
 	}
 }
 
-func TestNugetProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
+// TestNugetProxyUpdateStateFromApiPreservesFirewallBlockWhenDisabledButConfigured verifies
+// the GH-469 fix: repository_firewall is Optional-but-not-Computed, so once the practitioner
+// has configured it (even with enabled = false), Terraform's plan is always a non-null
+// object. Nulling the whole attribute out just because the server resolves the mode as
+// disabled - the previous behavior - made apply fail with "Provider produced inconsistent
+// result after apply". The block must be preserved, populated with the disabled flags,
+// instead.
+func TestNugetProxyUpdateStateFromApiPreservesFirewallBlockWhenDisabledButConfigured(t *testing.T) {
 	f := &NugetRepositoryFormatProxy{}
 	mode := common.FirewallModeDisabled
 
-	// An existing repository_firewall block in state must be cleared when the server
-	// reports the mode as disabled.
 	stateModel := f.UpdateStateFromApi(model.RepositoryNugetProxyModel{
 		FirewallAuditAndQuarantine: model.NewFirewallAuditAndQuarantineModelWithDefaults(),
 	}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.NugetProxyApiRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryNugetProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.CapabilityId.IsNull())
+	}
+}
+
+// TestNugetProxyUpdateStateFromApiClearsFirewallWhenDisabledAndUnconfigured is the case that
+// legitimately clears repository_firewall: it was never configured to begin with, so the
+// plan already expects null and there's nothing to preserve.
+func TestNugetProxyUpdateStateFromApiClearsFirewallWhenDisabledAndUnconfigured(t *testing.T) {
+	f := &NugetRepositoryFormatProxy{}
+	mode := common.FirewallModeDisabled
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryNugetProxyModel{}, ProxyApiResponseWithFirewall{
 		Repository:   sonatyperepo.NugetProxyApiRepository{},
 		FirewallMode: &mode,
 	}).(model.RepositoryNugetProxyModel)
@@ -166,17 +190,35 @@ func TestPyPiProxyUpdateStateFromApiUnwrapsFirewallMode(t *testing.T) {
 	}
 }
 
-// TestPyPiProxyUpdateStateFromApiClearsFirewallWhenDisabled mirrors
-// TestNugetProxyUpdateStateFromApiUnwrapsFirewallMode above for PyPI: an existing
-// repository_firewall block in state must be cleared when the server reports the mode as
-// disabled.
-func TestPyPiProxyUpdateStateFromApiClearsFirewallWhenDisabled(t *testing.T) {
+// TestPyPiProxyUpdateStateFromApiPreservesFirewallBlockWhenDisabledButConfigured mirrors
+// TestNugetProxyUpdateStateFromApiPreservesFirewallBlockWhenDisabledButConfigured above for
+// PyPI - see GH-469.
+func TestPyPiProxyUpdateStateFromApiPreservesFirewallBlockWhenDisabledButConfigured(t *testing.T) {
 	f := &PyPiRepositoryFormatProxy{}
 	mode := common.FirewallModeDisabled
 
 	stateModel := f.UpdateStateFromApi(model.RepositoryPyPiProxyModel{
 		FirewallAuditAndQuarantine: model.NewFirewallAuditAndQuarantineWithPccsModelWithDefaults(),
 	}, ProxyApiResponseWithFirewall{
+		Repository:   sonatyperepo.PyPiProxyApiRepository{},
+		FirewallMode: &mode,
+	}).(model.RepositoryPyPiProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.PccsEnabled.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.CapabilityId.IsNull())
+	}
+}
+
+// TestPyPiProxyUpdateStateFromApiClearsFirewallWhenDisabledAndUnconfigured mirrors
+// TestNugetProxyUpdateStateFromApiClearsFirewallWhenDisabledAndUnconfigured above for PyPI.
+func TestPyPiProxyUpdateStateFromApiClearsFirewallWhenDisabledAndUnconfigured(t *testing.T) {
+	f := &PyPiRepositoryFormatProxy{}
+	mode := common.FirewallModeDisabled
+
+	stateModel := f.UpdateStateFromApi(model.RepositoryPyPiProxyModel{}, ProxyApiResponseWithFirewall{
 		Repository:   sonatyperepo.PyPiProxyApiRepository{},
 		FirewallMode: &mode,
 	}).(model.RepositoryPyPiProxyModel)
@@ -226,5 +268,135 @@ func TestRawProxyUpdateStateFromApiPreservesExistingFirewallWhenModeUnknown(t *t
 	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
 		assert.True(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
 		assert.True(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+	}
+}
+
+// TestResolveFirewallBlockFlags exercises the decision table behind the GH-469 fix directly:
+// repository_firewall must only be cleared (keep=false) when the server resolves the mode as
+// Disabled AND it was never configured to begin with. Every other combination must keep the
+// block, since either the practitioner configured it (so Terraform's plan already expects a
+// non-null object) or the resolved mode is one of Audit/Quarantine/Pccs (so there's a real
+// firewall configuration to report, configured or not - e.g. on import/drift).
+func TestResolveFirewallBlockFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		hadConfig    bool
+		mode         common.FirewallMode
+		expectedKeep bool
+	}{
+		{"disabled and unconfigured clears the block", false, common.FirewallModeDisabled, false},
+		{"disabled but configured keeps the block", true, common.FirewallModeDisabled, true},
+		{"audit always keeps the block", false, common.FirewallModeAudit, true},
+		{"quarantine always keeps the block", false, common.FirewallModeQuarantine, true},
+		{"pccs always keeps the block", false, common.FirewallModePccs, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keep, enabled, quarantine, pccsEnabled := ResolveFirewallBlockFlags(tt.hadConfig, tt.mode)
+			assert.Equal(t, tt.expectedKeep, keep)
+
+			expectedEnabled, expectedQuarantine, expectedPccsEnabled := FirewallFlagsFromMode(tt.mode)
+			assert.Equal(t, expectedEnabled, enabled)
+			assert.Equal(t, expectedQuarantine, quarantine)
+			assert.Equal(t, expectedPccsEnabled, pccsEnabled)
+		})
+	}
+}
+
+// TestBackfillFirewallBlockFromPlan covers the second half of the GH-469 fix: Update() feeds
+// UpdateStateFromApi the PRIOR state rather than the new plan (see repository_common.go), so
+// adding repository_firewall for the first time with enabled = false in the same apply isn't
+// visible to ResolveFirewallBlockFlags there - state ends up nil even though the plan expects
+// an object. UpdateStateFromPlanForNonApiFields (which has both the plan and the post-read
+// state) must catch this up.
+func TestBackfillFirewallBlockFromPlan(t *testing.T) {
+	t.Run("backfills from plan when state is nil but plan configured the block", func(t *testing.T) {
+		planFirewall := &model.FirewallAuditAndQuarantineModel{
+			CapabilityId: types.StringValue("should-be-cleared"),
+			Enabled:      types.BoolValue(false),
+			Quarantine:   types.BoolValue(false),
+		}
+
+		result := BackfillFirewallBlockFromPlan(nil, planFirewall)
+
+		if assert.NotNil(t, result) {
+			assert.False(t, result.Enabled.ValueBool())
+			assert.False(t, result.Quarantine.ValueBool())
+			assert.True(t, result.CapabilityId.IsNull())
+		}
+	})
+
+	t.Run("leaves state nil when plan never configured the block either", func(t *testing.T) {
+		assert.Nil(t, BackfillFirewallBlockFromPlan(nil, nil))
+	})
+
+	t.Run("never overwrites a non-nil state value", func(t *testing.T) {
+		stateFirewall := &model.FirewallAuditAndQuarantineModel{Enabled: types.BoolValue(true)}
+		planFirewall := &model.FirewallAuditAndQuarantineModel{Enabled: types.BoolValue(false)}
+
+		result := BackfillFirewallBlockFromPlan(stateFirewall, planFirewall)
+
+		assert.Same(t, stateFirewall, result)
+	})
+}
+
+// TestBackfillFirewallBlockWithPccsFromPlan mirrors TestBackfillFirewallBlockFromPlan for the
+// PCCS-capable variant of the block (NPM, PyPI).
+func TestBackfillFirewallBlockWithPccsFromPlan(t *testing.T) {
+	t.Run("backfills from plan when state is nil but plan configured the block", func(t *testing.T) {
+		planFirewall := &model.FirewallAuditAndQuarantineWithPccsModel{
+			FirewallAuditAndQuarantineModel: model.FirewallAuditAndQuarantineModel{
+				CapabilityId: types.StringValue("should-be-cleared"),
+				Enabled:      types.BoolValue(false),
+				Quarantine:   types.BoolValue(false),
+			},
+			PccsEnabled: types.BoolValue(false),
+		}
+
+		result := BackfillFirewallBlockWithPccsFromPlan(nil, planFirewall)
+
+		if assert.NotNil(t, result) {
+			assert.False(t, result.Enabled.ValueBool())
+			assert.False(t, result.Quarantine.ValueBool())
+			assert.False(t, result.PccsEnabled.ValueBool())
+			assert.True(t, result.CapabilityId.IsNull())
+		}
+	})
+
+	t.Run("leaves state nil when plan never configured the block either", func(t *testing.T) {
+		assert.Nil(t, BackfillFirewallBlockWithPccsFromPlan(nil, nil))
+	})
+}
+
+// TestNpmProxyUpdateStateFromPlanForNonApiFieldsBackfillsNewlyConfiguredFirewall reproduces
+// the exact GH-469 scenario end-to-end for the format it was originally filed against:
+// adding `repository_firewall = { enabled = false }` for the first time in the same apply
+// that changes other attributes. Update()'s call into UpdateStateFromApi is fed the prior
+// state (which has no repository_firewall block), so the state produced there is nil even
+// though the new plan configured it - UpdateStateFromPlanForNonApiFields must reconcile that
+// before it reaches Terraform's post-apply consistency check.
+func TestNpmProxyUpdateStateFromPlanForNonApiFieldsBackfillsNewlyConfiguredFirewall(t *testing.T) {
+	f := &NpmRepositoryFormatProxy{}
+
+	planModel := model.RepositoryNpmProxyModel{
+		FirewallAuditAndQuarantine: &model.FirewallAuditAndQuarantineWithPccsModel{
+			FirewallAuditAndQuarantineModel: model.FirewallAuditAndQuarantineModel{
+				Enabled:    types.BoolValue(false),
+				Quarantine: types.BoolValue(false),
+			},
+			PccsEnabled: types.BoolValue(false),
+		},
+	}
+	// Simulates the state UpdateStateFromApi would have produced from prior (unconfigured) state.
+	stateAfterApiUpdate := model.RepositoryNpmProxyModel{}
+
+	stateModel := f.UpdateStateFromPlanForNonApiFields(planModel, stateAfterApiUpdate).(model.RepositoryNpmProxyModel)
+
+	if assert.NotNil(t, stateModel.FirewallAuditAndQuarantine) {
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Enabled.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.Quarantine.ValueBool())
+		assert.False(t, stateModel.FirewallAuditAndQuarantine.PccsEnabled.ValueBool())
+		assert.True(t, stateModel.FirewallAuditAndQuarantine.CapabilityId.IsNull())
 	}
 }

--- a/internal/provider/repository/format/pub.go
+++ b/internal/provider/repository/format/pub.go
@@ -168,7 +168,7 @@ func (f *PubRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, stat
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/pub.go
+++ b/internal/provider/repository/format/pub.go
@@ -140,13 +140,13 @@ func (f *PubRepositoryFormatProxy) UpdateStateFromApi(state, api any) any {
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -168,6 +168,7 @@ func (f *PubRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, stat
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/pypi.go
+++ b/internal/provider/repository/format/pypi.go
@@ -243,7 +243,7 @@ func (f *PyPiRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, sta
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockWithPccsFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPccsPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/pypi.go
+++ b/internal/provider/repository/format/pypi.go
@@ -214,13 +214,13 @@ func (f *PyPiRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.PyPiProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, pccsEnabled := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineWithPccsModelWithDefaults()
 				}
-				enabled, quarantine, pccsEnabled := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -243,6 +243,7 @@ func (f *PyPiRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, sta
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockWithPccsFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/r.go
+++ b/internal/provider/repository/format/r.go
@@ -240,7 +240,7 @@ func (f *RRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, state 
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/r.go
+++ b/internal/provider/repository/format/r.go
@@ -212,13 +212,13 @@ func (f *RRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -240,6 +240,7 @@ func (f *RRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, state 
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/raw.go
+++ b/internal/provider/repository/format/raw.go
@@ -224,13 +224,13 @@ func (f *RawRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.RawProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)

--- a/internal/provider/repository/format/ruby_gems.go
+++ b/internal/provider/repository/format/ruby_gems.go
@@ -214,13 +214,13 @@ func (f *RubyGemsRepositoryFormatProxy) UpdateStateFromApi(state any, api any) a
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.SimpleApiProxyRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -242,6 +242,7 @@ func (f *RubyGemsRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan,
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/ruby_gems.go
+++ b/internal/provider/repository/format/ruby_gems.go
@@ -242,7 +242,7 @@ func (f *RubyGemsRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan,
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/yum.go
+++ b/internal/provider/repository/format/yum.go
@@ -250,7 +250,7 @@ func (f *YumRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, stat
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
-	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
+	stateModel.FirewallAuditAndQuarantine = ReconcileFirewallBlockWithPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/format/yum.go
+++ b/internal/provider/repository/format/yum.go
@@ -222,13 +222,13 @@ func (f *YumRepositoryFormatProxy) UpdateStateFromApi(state any, api any) any {
 	if wrapped, ok := api.(ProxyApiResponseWithFirewall); ok {
 		stateModel.FromApiModel((wrapped.Repository).(sonatyperepo.YumProxyApiRepository))
 		if wrapped.FirewallMode != nil {
-			if *wrapped.FirewallMode == common.FirewallModeDisabled {
+			keep, enabled, quarantine, _ := ResolveFirewallBlockFlags(stateModel.FirewallAuditAndQuarantine != nil, *wrapped.FirewallMode)
+			if !keep {
 				stateModel.FirewallAuditAndQuarantine = nil
 			} else {
 				if stateModel.FirewallAuditAndQuarantine == nil {
 					stateModel.FirewallAuditAndQuarantine = model.NewFirewallAuditAndQuarantineModelWithDefaults()
 				}
-				enabled, quarantine, _ := FirewallFlagsFromMode(*wrapped.FirewallMode)
 				stateModel.FirewallAuditAndQuarantine.CapabilityId = types.StringNull()
 				stateModel.FirewallAuditAndQuarantine.Enabled = types.BoolValue(enabled)
 				stateModel.FirewallAuditAndQuarantine.Quarantine = types.BoolValue(quarantine)
@@ -250,6 +250,7 @@ func (f *YumRepositoryFormatProxy) UpdateStateFromPlanForNonApiFields(plan, stat
 	}
 
 	stateModel.MapMissingApiFieldsFromPlan(planModel)
+	stateModel.FirewallAuditAndQuarantine = BackfillFirewallBlockFromPlan(stateModel.FirewallAuditAndQuarantine, planModel.FirewallAuditAndQuarantine)
 	return stateModel
 }
 

--- a/internal/provider/repository/repository_common_proxy_test.go
+++ b/internal/provider/repository/repository_common_proxy_test.go
@@ -1098,6 +1098,27 @@ func repositoryFirewallBlockHcl(enabled, quarantine, pccsEnabled bool) string {
   }`, quarantine)
 }
 
+// repositoryFirewallBlockHclExplicit renders an explicit repository_firewall block even when
+// disabled (enabled = false), unlike repositoryFirewallBlockHcl above which omits the block
+// entirely in that case. This is what reproduces the LITERAL GH-469 report: the block was
+// present in the practitioner's HCL with enabled = false, not omitted - repository_firewall is
+// Optional-but-not-Computed, so Terraform's plan is a non-null object in that case, whereas
+// omitting the block plans null. Those are different scenarios for the provider's state
+// reconciliation even though both disable the firewall server-side.
+func repositoryFirewallBlockHclExplicit(enabled, quarantine, pccsEnabled bool) string {
+	if pccsEnabled {
+		return fmt.Sprintf(`repository_firewall = {
+    enabled = %t
+    quarantine = %t
+    pccs_enabled = true
+  }`, enabled, quarantine)
+	}
+	return fmt.Sprintf(`repository_firewall = {
+    enabled = %t
+    quarantine = %t
+  }`, enabled, quarantine)
+}
+
 // repositoryProxyResourceConfigWithFirewall builds a minimal proxy repository config with the
 // given (possibly empty) repository_firewall block appended.
 func repositoryProxyResourceConfigWithFirewall(resourceType, repoName, remoteUrl, formatSpecificConfig, firewallBlock string) string {
@@ -1129,11 +1150,16 @@ resource "%s" "repo" {
 }
 
 // TestAccRepositoryGenericProxyFirewallToggle exercises repository_firewall against a real,
-// connected Sonatype IQ Server across every inline-firewall-capable proxy format: enabling it,
-// then disabling it again. That disable step is the exact regression class reported in #469 and
-// #412 - NXRM omits the repository_firewall field entirely from its response once disabled, and
-// the provider previously produced "inconsistent result after apply" rather than clearing state
-// cleanly.
+// connected Sonatype IQ Server across every inline-firewall-capable proxy format, covering both
+// ways a practitioner disables it after it was enabled:
+//   - explicitly setting enabled = false while keeping the repository_firewall block in HCL -
+//     the LITERAL scenario reported in #469: repository_firewall is Optional-but-not-Computed,
+//     so Terraform's plan is a non-null object in this case, and the provider previously nulled
+//     the whole attribute out regardless, producing "inconsistent result after apply".
+//   - removing the repository_firewall block from HCL entirely - the scenario #412 and this
+//     test's step 3 exercise. NXRM omits the field entirely from its response either way once
+//     disabled, but the two HCL shapes are different inputs to the provider's state
+//     reconciliation and both must converge cleanly.
 func TestAccRepositoryGenericProxyFirewallToggle(t *testing.T) {
 	for _, td := range firewallProxyTestDataTable {
 		t.Run(td.RepoFormat, func(t *testing.T) {
@@ -1181,7 +1207,24 @@ func TestAccRepositoryGenericProxyFirewallToggle(t *testing.T) {
 				})
 			}
 
-			// 3. Back to no firewall configuration - the #469/#412 regression scenario
+			// 3. Explicitly disabled - repository_firewall block still present in HCL, with
+			// enabled = false. This is the LITERAL #469 regression scenario: the plan is a
+			// non-null object (the block is configured), so the provider must keep it in state
+			// rather than nulling the whole attribute the way it previously did just because
+			// NXRM's response omits `firewall` once disabled.
+			steps = append(steps, resource.TestStep{
+				Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHclExplicit(false, false, false)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_ENABLED, "false"),
+					resource.TestCheckResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_QUARANTINE, "false"),
+					resource.TestCheckNoResourceAttr(resourceName, repotest.RES_ATTR_REPOSITORY_FIREWALL_CAPABILITY_ID),
+				),
+			})
+
+			// 4. Back to no firewall configuration at all (block removed from HCL, not just
+			// enabled = false) - the #412 scenario, and the opposite-direction transition
+			// (configured -> unconfigured) that this fix's Update()-path reconciliation must
+			// also get right.
 			steps = append(steps, resource.TestStep{
 				Config: repositoryProxyResourceConfigWithFirewall(resourceType, repoName, td.RemoteUrl, td.FormatSpecificConfig, repositoryFirewallBlockHcl(false, false, false)),
 				Check: resource.ComposeAggregateTestCheckFunc(


### PR DESCRIPTION
## Summary
- Fixes #469: `sonatyperepo_repository_npm_proxy` (and every other NXRM 3.94+ inline-firewall proxy format - alpine, cargo, cocoapods, composer, conan, conda, docker, go, huggingface, maven, nuget, pypi, r, pub, raw, rubygems, yum) produced `Provider produced inconsistent result after apply` when `repository_firewall.enabled = false` was left explicitly configured in HCL. `repository_firewall` is Optional-but-not-Computed, so Terraform's plan is a non-null object once the block is configured at all, even with `enabled = false` - the provider was unconditionally nulling the whole attribute out whenever NXRM resolved the mode as disabled, regardless of whether the block was actually configured.
- `ResolveFirewallBlockFlags` (in `internal/provider/repository/format/proxy.go`) now only clears the block when it was never configured; a resolved `Disabled` mode is otherwise just another set of flags to report, same as Audit/Quarantine/Pccs.
- `ReconcileFirewallBlockWithPlan`/`ReconcileFirewallBlockWithPccsPlan` cover the one case that can't see on its own: `Update()` feeds `UpdateStateFromApi` the *prior* state rather than the new plan, so both directions of a same-apply transition (adding the block for the first time with `enabled = false`, or removing it entirely after it had been enabled) need reconciling from `UpdateStateFromPlanForNonApiFields` instead, which has both. The second direction was a regression caught during review of this fix, before landing it - see commit `aa69570`.
- `TestAccRepositoryGenericProxyFirewallToggle` (live, IQ-Server-backed) now has a dedicated step reproducing the literal #469 HCL shape (explicit `enabled = false`, not just an omitted block), alongside the existing block-removal step - both directions are now proven live, not just at the unit level.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all clean
- [x] New/updated unit tests in `internal/provider/repository/format/proxy_inline_firewall_test.go` reproduce both the original bug and the reconciliation regression found in review, end-to-end through the exact `Update()` call sequence
- [x] Live acceptance run against a real, connected Sonatype IQ Server (workflow_dispatch on this branch): `TestAccRepositoryGenericProxyFirewallToggle` passes for all 15 formats on both NXRM 3.94.1-06 (the reported version) and 3.95.1-01 - https://github.com/sonatype-nexus-community/terraform-provider-sonatyperepo/actions/runs/33155081870
- [x] `TestAccRepositoryGenericProxyFirewallToggle` passed 3 for 3 runs of the one consistently-flaky job (`Acc. Tests (NXRM 3.94.1-06 + TF 1.7.*)`). Each of its 3 failures was a *different* test in `internal/provider/{system,capability}` - `TestAccSystemIqConnectionResource`, then `TestAccCapabilityWebhookGlobalResource`, then `TestAccCapabilityUiBrandingResource` - the latter two with the identical NXRM-side signature (`500 Server Error ... java.lang.NullPointerException`, "Capability did not exist to read") on whichever capability-resource test happened to run next. This points to a pre-existing stability issue in NXRM 3.94.1-06's Capabilities REST endpoint under this job's back-to-back capability acceptance tests - unrelated to this diff, which touches neither the `capability` nor `system` packages. Not re-running further; worth a separate look if it keeps recurring on `main`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

