### PR TITLE
fix: Read plan instead of config in SSRF Protection Create (GH-476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## UNRELEASED
 
-*tbc
+BUG FIXES:
+* Prevent `Provider produced inconsistent result after apply` error when `allowed_domains`/`allowed_ips` are omitted from config on initial `terraform apply` for `sonatyperepo_security_ssrf_protection` [GH-476] - `Create` was reading from the raw config instead of the plan, so the schema's empty-set default never made it into state
 
 ## 1.18.0 Sep 07, 2026
 

--- a/internal/provider/system/security_ssrf_protection_resource.go
+++ b/internal/provider/system/security_ssrf_protection_resource.go
@@ -117,7 +117,7 @@ func (r *securitySsrfProtectionResource) ImportState(ctx context.Context, req re
 // Create creates the resource and sets the initial Terraform state.
 func (r *securitySsrfProtectionResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var plan model.SsrfProtectionModel
-	resp.Diagnostics.Append(req.Config.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 
 	if resp.Diagnostics.HasError() {
 		tflog.Error(ctx, fmt.Sprintf("Getting request data has errors: %v", resp.Diagnostics.Errors()))

--- a/internal/provider/system/security_ssrf_protection_resource_test.go
+++ b/internal/provider/system/security_ssrf_protection_resource_test.go
@@ -183,6 +183,31 @@ func TestAccSecuritySsrfProtectionResourceUpdate(t *testing.T) {
 	})
 }
 
+// TestAccSecuritySsrfProtectionResourceCreateWithOmittedAllowedIPs reproduces GH-476:
+// creating the resource while leaving the optional/computed "allowed_ips" attribute
+// entirely unset in config (relying on its schema default) fails on the very first
+// apply with "Provider produced inconsistent result after apply: .allowed_ips: was
+// cty.SetValEmpty(cty.String), but now null."
+func TestAccSecuritySsrfProtectionResourceCreateWithOmittedAllowedIPs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: utils_test.TestAccProtoV6ProviderFactories,
+		PreCheck: func() {
+			// Not supported prior to NXRM 3.92.0
+			skipIfSsrfProtectionUnsupported(t)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: getSecuritySsrfProtectionResourceConfigWithOmittedAllowedIPs(true, []string{"internal.example.com"}),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameSecuritySsrfProtection, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceNameSecuritySsrfProtection, "allowed_domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameSecuritySsrfProtection, "allowed_ips.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func getSecuritySsrfProtectionResourceConfig(enabled bool, allowedDomains []string, allowedIPs []string) string {
 	return fmt.Sprintf(utils_test.ProviderConfig+`
 resource "%s" "ssrf" {
@@ -191,6 +216,18 @@ resource "%s" "ssrf" {
 	allowed_ips = %s
 }
 `, resourceTypeSecuritySsrfProtection, enabled, toHclStringList(allowedDomains), toHclStringList(allowedIPs))
+}
+
+// getSecuritySsrfProtectionResourceConfigWithOmittedAllowedIPs builds a config that
+// leaves "allowed_ips" out of the resource block entirely (as opposed to setting it
+// to an explicit empty list), matching the reporter's original configuration in GH-476.
+func getSecuritySsrfProtectionResourceConfigWithOmittedAllowedIPs(enabled bool, allowedDomains []string) string {
+	return fmt.Sprintf(utils_test.ProviderConfig+`
+resource "%s" "ssrf" {
+	enabled = %t
+	allowed_domains = %s
+}
+`, resourceTypeSecuritySsrfProtection, enabled, toHclStringList(allowedDomains))
 }
 
 func toHclStringList(values []string) string {


### PR DESCRIPTION
When allowed_ips/allowed_domains were omitted from config, Create read req.Config instead of req.Plan, so the schema's empty-set default (only applied to the plan) never made it into state. This produced "Provider produced inconsistent result after apply: .allowed_ips: was cty.SetValEmpty(cty.String), but now null" on first apply.

Update already used req.Plan; Create now matches it. Adds a regression test that creates the resource with allowed_ips omitted, reproducing the bug against a live NXRM before the fix and passing after.

Resolves #476 