### PR TITLE
fix: Add missing `oci` and `pub` formats to cleanup policy enum (GH-483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 BUG FIXES:
 * Prevent `Provider produced inconsistent result after apply` error when `allowed_domains`/`allowed_ips` are omitted from config on initial `terraform apply` for `sonatyperepo_security_ssrf_protection` [GH-476] - `Create` was reading from the raw config instead of the plan, so the schema's empty-set default never made it into state
+* `sonatyperepo_cleanup_policy` rejected valid `format = "oci"` values [GH-483] - the `format` enum was never updated when the OCI and Pub repository formats were added, so `pub` was also missing and has been added alongside `oci`
 
 ## 1.18.0 Sep 07, 2026
 

--- a/internal/provider/repository/cleanup_policies.go
+++ b/internal/provider/repository/cleanup_policies.go
@@ -80,7 +80,7 @@ func (r *cleanupPolicyResource) Schema(_ context.Context, _ resource.SchemaReque
 			"notes": schema.ResourceOptionalString("Notes for the cleanup policy"),
 			"format": schema.ResourceRequiredStringEnum(
 				"Repository format that this cleanup policy applies to",
-				"*", "alpine", "ansiblegalaxy", "apt", "cargo", "cocoapods", "composer", "conan", "conda", "docker", "gitlfs", "go", "helm", "huggingface", "maven2", "npm", "nuget", "p2", "pypi", "r", "raw", "rubygems", "swift", "terraform", "yum",
+				"*", "alpine", "ansiblegalaxy", "apt", "cargo", "cocoapods", "composer", "conan", "conda", "docker", "gitlfs", "go", "helm", "huggingface", "maven2", "npm", "nuget", "oci", "p2", "pub", "pypi", "r", "raw", "rubygems", "swift", "terraform", "yum",
 			),
 			"criteria": schema.ResourceRequiredSingleNestedAttribute(
 				"Cleanup criteria for this policy - at least one criterion must be specified",


### PR DESCRIPTION
The format enum for `sonatyperepo_cleanup_policy` was never updated when the `oci` and `pub` repository formats were added, causing schema validation to reject valid cleanup policies for those formats.

Resolves #483 